### PR TITLE
Allow for additional customization of table definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const definitions: Database = await sqlts.toObject(config)
 
 ### fromObject
 
-Converts the object returned from `toObject` into a TypeScript definition.
+Converts the object returned from `toObject` into a TypeScript definition. This can be used to manipulate the database definitions before they are converted into strings or files, which allows for greater control over the generated typescript.
 
 ```javascript
 import sqlts from '@rmp135/sql-ts'

--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ Determines whether properties are optional. Valid values are `optional` (all pro
 }
 ```
 
+### createClasses
+
+Allows creation of concrete classes instead of interfaces. Valid values are `true` or `false`. This property is optional and defaults to `false`
+
+```json
+{
+  "dialect": "...",
+  "connection": {},
+  "createClasses": true
+}
+```
+
 ## Bespoke Configuration
 
 ### `mssql` dialect with `msnodesqlv8` driver (Windows only)

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -89,7 +89,8 @@ exports.getAllTables = getAllTables;
  */
 function stringifyTable(table, config) {
     var createTableAs = config.createClasses ? 'class' : 'interface';
-    var additionalProperties = table.additionalProperties ? "\n\t" + table.additionalProperties.join('\n') + "\n" : '';
+    var extend = table.extends ? " extends " + table.extends : '';
+    var additionalProperties = table.additionalProperties ? "\n  " + table.additionalProperties.join('\n') + "\n" : '';
     return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + " { " + additionalProperties + "\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
 }
 exports.stringifyTable = stringifyTable;

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -89,6 +89,12 @@ exports.getAllTables = getAllTables;
  */
 function stringifyTable(table, config) {
     var createTableAs = config.createClasses ? 'class' : 'interface';
-    return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + " {\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
+    var additionalProperties = table.additionalProperties ? "\n\t" + table.additionalProperties.join('\n') + "\n" : '';
+    return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + " { " + additionalProperties + "\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
 }
 exports.stringifyTable = stringifyTable;
+function createClassProperties(table, config) {
+    if (!config.createClasses)
+        return '';
+    return "\n  static get TABLE_NAME() { return '" + table.name + "'; }\n  ";
+}

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -93,8 +93,3 @@ function stringifyTable(table, config) {
     return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + " { " + additionalProperties + "\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
 }
 exports.stringifyTable = stringifyTable;
-function createClassProperties(table, config) {
-    if (!config.createClasses)
-        return '';
-    return "\n  static get TABLE_NAME() { return '" + table.name + "'; }\n  ";
-}

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -88,6 +88,7 @@ exports.getAllTables = getAllTables;
  * @returns {string}
  */
 function stringifyTable(table, config) {
-    return "export interface " + TableSubTasks.generateInterfaceName(table.name, config) + " {\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
+    var createTableAs = config.createClasses ? 'class' : 'interface';
+    return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + " {\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
 }
 exports.stringifyTable = stringifyTable;

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -90,7 +90,7 @@ exports.getAllTables = getAllTables;
 function stringifyTable(table, config) {
     var createTableAs = config.createClasses ? 'class' : 'interface';
     var extend = table.extends ? " extends " + table.extends : '';
-    var additionalProperties = table.additionalProperties ? "\n  " + table.additionalProperties.join('\n') + "\n" : '';
+    var additionalProperties = table.additionalProperties ? "\n  " + table.additionalProperties.join('\n  ') + "\n" : '';
     return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + extend + " { " + additionalProperties + "\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
 }
 exports.stringifyTable = stringifyTable;

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -91,6 +91,6 @@ function stringifyTable(table, config) {
     var createTableAs = config.createClasses ? 'class' : 'interface';
     var extend = table.extends ? " extends " + table.extends : '';
     var additionalProperties = table.additionalProperties ? "\n  " + table.additionalProperties.join('\n') + "\n" : '';
-    return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + " { " + additionalProperties + "\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
+    return "export " + createTableAs + " " + TableSubTasks.generateInterfaceName(table.name, config) + extend + " { " + additionalProperties + "\n" + table.columns.map(function (c) { return "  " + ColumnTasks.stringifyColumn(c, config); }).join('\n') + "\n}";
 }
 exports.stringifyTable = stringifyTable;

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -46,6 +46,13 @@ export interface Table {
     schema: string;
     columns: Column[];
     /**
+     * This string is a class or interface that this definition should extend
+     *
+     * @type {string}
+     * @memberof Table
+     */
+    extends?: string;
+    /**
      *  This array of string will be added as properties to the object
      *  when it is exported
      *

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -35,10 +35,23 @@ export interface Column {
     optional: boolean;
     nullable: boolean;
 }
+/**
+ * The JSON definition of a taboe for importing and exporting.
+ *
+ * @export
+ * @interface Table
+ */
 export interface Table {
     name: string;
     schema: string;
     columns: Column[];
+    /**
+     *  This array of string will be added as properties to the object
+     *  when it is exported
+     *
+     * @type {string[]}
+     * @memberof Table
+     */
     additionalProperties?: string[];
 }
 /**

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -20,6 +20,7 @@ export interface Config extends knex.Config {
         [key: string]: string;
     };
     propertyOptionality?: optionality;
+    createClasses?: boolean;
 }
 /**
  * The JSON definition of a column for importing and exporting.

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -39,6 +39,7 @@ export interface Table {
     name: string;
     schema: string;
     columns: Column[];
+    additionalProperties?: string[];
 }
 /**
  * The JSON definition of a database for importing and exporting.

--- a/src/TableTasks.spec.ts
+++ b/src/TableTasks.spec.ts
@@ -177,10 +177,11 @@ describe('TableTasks', () => {
         }
         const mockConfig = {
         }
-        mockTable.additionalProperties = ['extra property']
+        mockTable.additionalProperties = ['extra property 1', 'extra property 2']
         const result = MockTableTasks.stringifyTable(mockTable as any, mockConfig as any)
         expect(result).toBe(`export interface interfacename { 
-  extra property
+  extra property 1
+  extra property 2
 
   column 1 string
 }`)

--- a/src/TableTasks.spec.ts
+++ b/src/TableTasks.spec.ts
@@ -1,5 +1,6 @@
 import 'jasmine'
 import * as TableTasks from './TableTasks';
+import { Table } from './Typings'
 const rewire = require('rewire')
 
 let RewireTableTasks = rewire('./TableTasks')
@@ -123,10 +124,65 @@ describe('TableTasks', () => {
         expect(mockColumnTasks.stringifyColumn.calls.argsFor(0)).toEqual([mockTable.columns[0], mockConfig])
         expect(mockColumnTasks.stringifyColumn.calls.argsFor(1)).toEqual([mockTable.columns[1], mockConfig])
         expect(mockColumnTasks.stringifyColumn.calls.argsFor(2)).toEqual([mockTable.columns[2], mockConfig])
-        expect(result).toBe(`export interface interfacename {
+        expect(result).toBe(`export interface interfacename { 
   column 1 string
   column 2 string
   column 3 string
+}`)
+      })
+    })
+
+    it('can create tables as classes', () => {
+      const mockColumnTasks = {
+        stringifyColumn: jasmine.createSpy('stringifyColumn').and.returnValues('column 1 string', 'column 2 string', 'column 3 string')
+      }
+      const mockTableSubTasks = {
+        generateInterfaceName: jasmine.createSpy('generateInterfaceName').and.returnValue('interfacename')
+      }
+      MockTableTasks.__with__({
+        ColumnTasks: mockColumnTasks,
+        TableSubTasks: mockTableSubTasks
+      })(() => {
+        const mockTable = {
+          name: 'tablename',
+          columns: [1,2,3]
+        }
+        const mockConfig = {
+          createClasses: true
+        }
+        const result = MockTableTasks.stringifyTable(mockTable as any, mockConfig as any)
+        expect(result).toBe(`export class interfacename { 
+  column 1 string
+  column 2 string
+  column 3 string
+}`)
+      })
+    })
+
+    it('accepts additional properties for definitions', () => {
+      const mockColumnTasks = {
+        stringifyColumn: jasmine.createSpy('stringifyColumn').and.returnValues('column 1 string')
+      }
+      const mockTableSubTasks = {
+        generateInterfaceName: jasmine.createSpy('generateInterfaceName').and.returnValue('interfacename')
+      }
+      MockTableTasks.__with__({
+        ColumnTasks: mockColumnTasks,
+        TableSubTasks: mockTableSubTasks
+      })(() => {
+        const mockTable: Table = {
+          name: 'tablename',
+          columns: [{name: 'columnName', type: 'string', jsType: 'string', optional: true, nullable: true}],
+          schema: 'schemaName'
+        }
+        const mockConfig = {
+        }
+        mockTable.additionalProperties = ['extra property']
+        const result = MockTableTasks.stringifyTable(mockTable as any, mockConfig as any)
+        expect(result).toBe(`export interface interfacename { 
+  extra property
+
+  column 1 string
 }`)
       })
     })

--- a/src/TableTasks.spec.ts
+++ b/src/TableTasks.spec.ts
@@ -186,5 +186,34 @@ describe('TableTasks', () => {
 }`)
       })
     })
+
+    it('can be extended', () => {
+      const mockColumnTasks = {
+        stringifyColumn: jasmine.createSpy('stringifyColumn').and.returnValues('column 1 string')
+      }
+      const mockTableSubTasks = {
+        generateInterfaceName: jasmine.createSpy('generateInterfaceName').and.returnValue('interfacename')
+      }
+      MockTableTasks.__with__({
+        ColumnTasks: mockColumnTasks,
+        TableSubTasks: mockTableSubTasks
+      })(() => {
+        const mockTable: Table = {
+          name: 'tablename',
+          columns: [{name: 'columnName', type: 'string', jsType: 'string', optional: true, nullable: true}],
+          schema: 'schemaName',
+          extends: 'testInterface'
+        }
+        const mockConfig = {
+        }
+        mockTable.additionalProperties = ['extra property']
+        const result = MockTableTasks.stringifyTable(mockTable as any, mockConfig as any)
+        expect(result).toBe(`export interface interfacename extends testInterface { 
+  extra property
+
+  column 1 string
+}`)
+      })
+    })
   })
 })

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -35,7 +35,7 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
 export function stringifyTable (table: Table, config: Config): string {
   const createTableAs = config.createClasses ? 'class' : 'interface';
   const extend = table.extends ? ` extends ${table.extends}` : '';
-  const additionalProperties = table.additionalProperties ? `\n  ${table.additionalProperties.join('\n')}\n` : ''
+  const additionalProperties = table.additionalProperties ? `\n  ${table.additionalProperties.join('\n  ')}\n` : ''
   return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)}${extend} { ${additionalProperties}
 ${table.columns.map(c => `  ${ColumnTasks.stringifyColumn(c, config)}`).join('\n')}
 }`}

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -33,6 +33,7 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
  * @returns {string} 
  */
 export function stringifyTable (table: Table, config: Config): string {
-  return `export interface ${TableSubTasks.generateInterfaceName(table.name, config)} {
+  const createTableAs = config.createClasses ? 'class' : 'interface';
+  return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)} {
 ${table.columns.map(c => `  ${ColumnTasks.stringifyColumn(c, config)}`).join('\n')}
 }`}

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -34,7 +34,8 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
  */
 export function stringifyTable (table: Table, config: Config): string {
   const createTableAs = config.createClasses ? 'class' : 'interface';
+  const extend = table.extends ? ` extends ${table.extends}` : '';
   const additionalProperties = table.additionalProperties ? `\n  ${table.additionalProperties.join('\n')}\n` : ''
-  return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)} { ${additionalProperties}
+  return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)}${extend} { ${additionalProperties}
 ${table.columns.map(c => `  ${ColumnTasks.stringifyColumn(c, config)}`).join('\n')}
 }`}

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -34,6 +34,7 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
  */
 export function stringifyTable (table: Table, config: Config): string {
   const createTableAs = config.createClasses ? 'class' : 'interface';
-  return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)} {
+  const additionalProperties = table.additionalProperties ? `\n\t${table.additionalProperties.join('\n')}\n` : ''
+  return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)} { ${additionalProperties}
 ${table.columns.map(c => `  ${ColumnTasks.stringifyColumn(c, config)}`).join('\n')}
 }`}

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -34,7 +34,7 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
  */
 export function stringifyTable (table: Table, config: Config): string {
   const createTableAs = config.createClasses ? 'class' : 'interface';
-  const additionalProperties = table.additionalProperties ? `\n\t${table.additionalProperties.join('\n')}\n` : ''
+  const additionalProperties = table.additionalProperties ? `\n  ${table.additionalProperties.join('\n')}\n` : ''
   return `export ${createTableAs} ${TableSubTasks.generateInterfaceName(table.name, config)} { ${additionalProperties}
 ${table.columns.map(c => `  ${ColumnTasks.stringifyColumn(c, config)}`).join('\n')}
 }`}

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -51,6 +51,14 @@ export interface Table {
   columns: Column[]
 
   /**
+   * This string is a class or interface that this definition should extend
+   *
+   * @type {string}
+   * @memberof Table
+   */
+  extends?: string
+
+  /**
    *  This array of string will be added as properties to the object
    *  when it is exported
    *

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -21,7 +21,8 @@ export interface Config extends knex.Config {
   typeOverrides?: { 
     [key: string]: string 
   },
-  propertyOptionality?: optionality
+  propertyOptionality?: optionality,
+  createClasses?: boolean
 } 
 
 /**

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -39,10 +39,25 @@ export interface Column {
   nullable: boolean
 }
 
+/**
+ * The JSON definition of a taboe for importing and exporting.
+ * 
+ * @export
+ * @interface Table
+ */
 export interface Table {
   name: string,
   schema: string,
   columns: Column[]
+
+  /**
+   *  This array of string will be added as properties to the object
+   *  when it is exported
+   *
+   * @type {string[]}
+   * @memberof Table
+   */
+  additionalProperties?: string[],
 }
 
 /**


### PR DESCRIPTION
We are interested in using this library to extract typescript definitions from our database, however, we wanted the ability to generate concrete classes instead of typescript interfaces for use tooling that will automatically read and write these database objects to the db. 

These changes should not change the default behavior of the generator in anyway, but they do give more flexibility to users.