### PR TITLE
Create full database object prior to applying template

### DIFF
--- a/dist/DatabaseTasks.d.ts
+++ b/dist/DatabaseTasks.d.ts
@@ -8,3 +8,20 @@ import { Config, Database } from './Typings';
  * @returns A TypeScript definition, optionally wrapped in a namespace.
  */
 export declare function stringifyDatabase(database: Database, config: Config): string;
+export declare function decorateDatabase(database: Database, config: any): {
+    tables: {
+        interfaceName: string;
+        columns: {
+            propertyName: string;
+            propertyType: string;
+            name: string;
+            type: string;
+            optional: boolean;
+            nullable: boolean;
+        }[];
+        name: string;
+        schema: string;
+        extends?: string;
+        additionalProperties?: string[];
+    }[];
+};

--- a/dist/DatabaseTasks.js
+++ b/dist/DatabaseTasks.js
@@ -27,12 +27,15 @@ function stringifyDatabase(database, config) {
     if (config.template !== undefined)
         template = fs.readFileSync(config.template, 'utf-8');
     var compiler = handlebars.compile(template);
-    var tables = database.tables.map(function (t) {
-        return __assign({}, t, { interfaceName: TableTasks.generateInterfaceName(t.name, config), columns: t.columns.map(function (c) {
-                return __assign({}, c, { propertyName: c.name.replace(/ /g, ''), propertyType: ColumnTasks.convertType(t.name, t.schema, c.name, c.type, config) });
-            }) });
-    });
-    var grouped = _.groupBy(tables, function (t) { return t.schema; });
-    return compiler({ grouped: grouped, tables: tables, config: config });
+    var grouped = _.groupBy(database.tables, function (t) { return t.schema; });
+    return compiler({ grouped: grouped, tables: database.tables, config: config });
 }
 exports.stringifyDatabase = stringifyDatabase;
+function decorateDatabase(database, config) {
+    return __assign({}, database, { tables: database.tables.map(function (t) {
+            return __assign({}, t, { interfaceName: TableTasks.generateInterfaceName(t.name, config), columns: t.columns.map(function (c) {
+                    return __assign({}, c, { propertyName: c.name.replace(/ /g, ''), propertyType: ColumnTasks.convertType(t.name, t.schema, c.name, c.type, config) });
+                }) });
+        }) });
+}
+exports.decorateDatabase = decorateDatabase;

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,10 +45,13 @@ var DatabaseTasks = require("./DatabaseTasks");
  */
 function toObject(config) {
     return __awaiter(this, void 0, void 0, function () {
+        var database;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0: return [4 /*yield*/, DatabaseFactory.buildDatabase(config)];
-                case 1: return [2 /*return*/, _a.sent()];
+                case 1:
+                    database = _a.sent();
+                    return [2 /*return*/, DatabaseTasks.decorateDatabase(database, config)];
             }
         });
     });

--- a/src/DatabaseTasks.spec.ts
+++ b/src/DatabaseTasks.spec.ts
@@ -7,14 +7,44 @@ let RewireDatabaseTasks = rewire('./DatabaseTasks')
 const MockDatabaseTasks: typeof DatabaseTasks & typeof RewireDatabaseTasks = <any> RewireDatabaseTasks
 
 describe('DatabaseTasks', () => {
+  let mockDatabase
+
+  beforeEach(() => {
+    mockDatabase = {
+      tables: [
+      {
+        name: 'tname1',
+        schema: 'schema1',
+        columns: [
+          {
+            name: 'col1',
+            type: 'type1'
+          }
+        ]
+      },{
+        name: 'tname2',
+        schema: 'schema1',
+        columns: [
+          {
+            name: 'col2',
+            type: 'type2'
+          }
+        ]
+      },{
+        name: 'tname3',
+        schema: 'schema2',
+        columns: [
+          {
+            name: 'col3',
+            type: 'type3'
+          }
+        ]
+      }]
+    }
+  })
+
   describe('stringifyDatabase', () => {
     it('should use default template', () => {
-      const mockTableTasks = {
-        generateInterfaceName: jasmine.createSpy('generateInterfaceName').and.returnValues('name1', 'name2', 'name3')
-      }
-      const mockColumnTasks = {
-        convertType: jasmine.createSpy('convertType').and.returnValues('jsType1', 'jsType2', 'jsType3')
-      }
       const mockFs = {
         readFileSync: jasmine.createSpy('readFileSync').and.returnValue('defaultTemplate')
       }
@@ -23,64 +53,19 @@ describe('DatabaseTasks', () => {
         compile: jasmine.createSpy('compile').and.returnValue(mockCompileReturn)
       }
       MockDatabaseTasks.__with__({
-        TableTasks: mockTableTasks,
-        ColumnTasks: mockColumnTasks,
         fs: mockFs,
         handlebars: mockHandlebars
       })(() => {
-        const mockDatabase = {
-          tables: [
-          {
-            name: 'tname1',
-            schema: 'schema1',
-            columns: [
-              {
-                name: 'col1',
-                type: 'type1'
-              }
-            ]
-          },{
-            name: 'tname2',
-            schema: 'schema1',
-            columns: [
-              {
-                name: 'col2',
-                type: 'type2'
-              }
-            ]
-          },{
-            name: 'tname3',
-            schema: 'schema2',
-            columns: [
-              {
-                name: 'col3',
-                type: 'type3'
-              }
-            ]
-          }]
-        }
         const mockConfig = {
           schemaAsNamespace: true
         }
         const result = MockDatabaseTasks.stringifyDatabase(mockDatabase as any, mockConfig as any)
         expect(mockFs.readFileSync).toHaveBeenCalledWith(path.join(__dirname, './template.handlebars'), 'utf-8')
         expect(mockHandlebars.compile).toHaveBeenCalledWith('defaultTemplate')
-        expect(mockTableTasks.generateInterfaceName.calls.argsFor(0)).toEqual(['tname1', mockConfig])
-        expect(mockTableTasks.generateInterfaceName.calls.argsFor(1)).toEqual(['tname2', mockConfig])
-        expect(mockTableTasks.generateInterfaceName.calls.argsFor(2)).toEqual(['tname3', mockConfig])
-        expect(mockColumnTasks.convertType.calls.argsFor(0)).toEqual(['tname1', 'schema1', 'col1', 'type1', mockConfig])
-        expect(mockColumnTasks.convertType.calls.argsFor(1)).toEqual(['tname2', 'schema1', 'col2', 'type2', mockConfig])
-        expect(mockColumnTasks.convertType.calls.argsFor(2)).toEqual(['tname3', 'schema2', 'col3', 'type3', mockConfig])
         expect(result).toBe(`compiledTemplate`)
       })
     })
     it('should use supplied template', () => {
-      const mockTableTasks = {
-        generateInterfaceName: jasmine.createSpy('generateInterfaceName').and.returnValues('name1', 'name2', 'name3')
-      }
-      const mockColumnTasks = {
-        convertType: jasmine.createSpy('convertType').and.returnValues('jsType1', 'jsType2', 'jsType3')
-      }
       const mockFs = {
         readFileSync: jasmine.createSpy('readFileSync').and.returnValue('template')
       }
@@ -89,42 +74,9 @@ describe('DatabaseTasks', () => {
         compile: jasmine.createSpy('compile').and.returnValue(mockCompileReturn)
       }
       MockDatabaseTasks.__with__({
-        TableTasks: mockTableTasks,
-        ColumnTasks: mockColumnTasks,
         fs: mockFs,
         handlebars: mockHandlebars
       })(() => {
-        const mockDatabase = {
-          tables: [
-          {
-            name: 'tname1',
-            schema: 'schema1',
-            columns: [
-              {
-                name: 'col1',
-                type: 'type1'
-              }
-            ]
-          },{
-            name: 'tname2',
-            schema: 'schema1',
-            columns: [
-              {
-                name: 'col2',
-                type: 'type2'
-              }
-            ]
-          },{
-            name: 'tname3',
-            schema: 'schema2',
-            columns: [
-              {
-                name: 'col3',
-                type: 'type3'
-              }
-            ]
-          }]
-        }
         const mockConfig = {
           schemaAsNamespace: true,
           template: 'userdefinedtemplate'
@@ -132,14 +84,34 @@ describe('DatabaseTasks', () => {
         const result = MockDatabaseTasks.stringifyDatabase(mockDatabase as any, mockConfig as any)
         expect(mockFs.readFileSync).toHaveBeenCalledWith('userdefinedtemplate', 'utf-8')
         expect(mockHandlebars.compile).toHaveBeenCalledWith('template')
+        expect(result).toBe(`compiledTemplate`)
+      })
+    })
+  })
+
+  describe('decorateDatabase', () => {
+    it('decorates the database object with interface name and column types', () => {
+      const mockTableTasks = {
+        generateInterfaceName: jasmine.createSpy('generateInterfaceName').and.returnValues('name1', 'name2', 'name3')
+      }
+      const mockColumnTasks = {
+        convertType: jasmine.createSpy('convertType').and.returnValues('jsType1', 'jsType2', 'jsType3')
+      }
+      MockDatabaseTasks.__with__({
+        TableTasks: mockTableTasks,
+        ColumnTasks: mockColumnTasks,
+      })(() => {
+        const mockConfig = {
+          schemaAsNamespace: true
+        }
+        const result = MockDatabaseTasks.decorateDatabase(mockDatabase as any, mockConfig as any)
         expect(mockTableTasks.generateInterfaceName.calls.argsFor(0)).toEqual(['tname1', mockConfig])
         expect(mockTableTasks.generateInterfaceName.calls.argsFor(1)).toEqual(['tname2', mockConfig])
         expect(mockTableTasks.generateInterfaceName.calls.argsFor(2)).toEqual(['tname3', mockConfig])
         expect(mockColumnTasks.convertType.calls.argsFor(0)).toEqual(['tname1', 'schema1', 'col1', 'type1', mockConfig])
         expect(mockColumnTasks.convertType.calls.argsFor(1)).toEqual(['tname2', 'schema1', 'col2', 'type2', mockConfig])
         expect(mockColumnTasks.convertType.calls.argsFor(2)).toEqual(['tname3', 'schema2', 'col3', 'type3', mockConfig])
-        expect(result).toBe(`compiledTemplate`)
-      })
+      })      
     })
   })
 })

--- a/src/DatabaseTasks.ts
+++ b/src/DatabaseTasks.ts
@@ -19,9 +19,8 @@ export function stringifyDatabase (database: Database, config: Config) {
   if (config.template !== undefined)
     template = fs.readFileSync(config.template, 'utf-8')
   const compiler = handlebars.compile(template)
-  const tables = decorateDatabase(database, config).tables
-  const grouped = _.groupBy(tables, t => t.schema)
-  return compiler({ grouped, tables, config })
+  const grouped = _.groupBy(database.tables, t => t.schema)
+  return compiler({ grouped, tables: database.tables, config })
 }
 
 export function decorateDatabase(database: Database, config) {

--- a/src/DatabaseTasks.ts
+++ b/src/DatabaseTasks.ts
@@ -19,19 +19,26 @@ export function stringifyDatabase (database: Database, config: Config) {
   if (config.template !== undefined)
     template = fs.readFileSync(config.template, 'utf-8')
   const compiler = handlebars.compile(template)
-  const tables = database.tables.map(t => {
-    return {
-      ...t,
-      interfaceName: TableTasks.generateInterfaceName(t.name, config),
-      columns: t.columns.map(c => {
-        return {
-          ...c,
-          propertyName: c.name.replace(/ /g,''),
-          propertyType: ColumnTasks.convertType(t.name, t.schema, c.name, c.type, config)
-        }
-      })
-    }
-  })
+  const tables = decorateDatabase(database, config).tables
   const grouped = _.groupBy(tables, t => t.schema)
   return compiler({ grouped, tables, config })
+}
+
+export function decorateDatabase(database: Database, config) {
+  return {
+    ...database, 
+    tables: database.tables.map(t => {
+      return {
+        ...t,
+        interfaceName: TableTasks.generateInterfaceName(t.name, config),
+        columns: t.columns.map(c => {
+          return {
+            ...c,
+            propertyName: c.name.replace(/ /g,''),
+            propertyType: ColumnTasks.convertType(t.name, t.schema, c.name, c.type, config)
+          }
+        })
+      }
+    })  
+  }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -8,7 +8,7 @@ const Mockindex: typeof index & typeof Rewireindex = <any> Rewireindex
 describe('index', () => {
   describe('toObject', () => {
     it('should return an object from a database', (done) => {
-      const mockDatabase = { }
+      const mockDatabase = { tables: [] }
       const mockDatabaseFactory = {
         buildDatabase: jasmine.createSpy('buildDatabase').and.returnValue(Promise.resolve(mockDatabase))
       }
@@ -17,7 +17,7 @@ describe('index', () => {
       })(async () => {
         const mockConfig = { }
         const result = await Mockindex.toObject(mockConfig)
-        expect(result).toBe(mockDatabase as any)
+        expect(result).toEqual(mockDatabase as any)
         expect(mockDatabaseFactory.buildDatabase).toHaveBeenCalledWith(mockConfig)
         done()
       })
@@ -47,7 +47,8 @@ describe('index', () => {
         buildDatabase: jasmine.createSpy('buildDatabase').and.returnValue(Promise.resolve(mockDatabase)),
       }
       const mockDatabaseTasks = {
-        stringifyDatabase: jasmine.createSpy('stringifyDatabase').and.returnValue('database string')
+        stringifyDatabase: jasmine.createSpy('stringifyDatabase').and.returnValue('database string'),
+        decorateDatabase: jasmine.createSpy('decorateDatabase').and.returnValue(mockDatabase)
       }
       Mockindex.__with__({
         DatabaseFactory: mockDatabaseFactory,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import * as DatabaseTasks from './DatabaseTasks'
  * @returns {Promise<Database>} The Database definition as a plain JavaScript object.
  */
 async function toObject (config: Config): Promise<Database> {
-  return await DatabaseFactory.buildDatabase(config)
+  const database = await DatabaseFactory.buildDatabase(config)
+  return DatabaseTasks.decorateDatabase(database, config);
 }
 
 /**


### PR DESCRIPTION
This separates the decoration of the database object from the stringifyDatabase command so that we can operate on the full object after calling toObject, but before applying the template.