### PR TITLE
Add support for special interfaceNameFormat value "PascalCase"

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Specifies the name that the file should be saved as. Defaults to "Database.ts". 
 
 Specifies the pattern that the exported interface names will take. The token "${table}" will be replaced with the table name. Defaults to "${table}Entity".
 
+This property also supports the special value `PascalCase`. In this case, the table name will be transformed by removing the underscores and adding an converting the words to title case. Thus "user_sessions" would become "UserSessions".
+
 The below will export interfaces with such names as `UserModel` and `LogModel` for tables with names `User` and `Log` respectively.
 
 ```json

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This property also supports special values that transform the table name accordi
 
 - `PascalCase`: in this case, the table name will be transformed by removing the underscores and adding an converting the words to title case. Thus "user_sessions" would become "UserSessions".
 
-- `PascalCaseSingular`: table names are some times plural but it is preferable if the entity names are singular. This format transform the table name like PascalCase but also make the words singular. Thus "user_session" will become "UserSession" and "users" will become "User".
+- `PascalCaseSingular`: table names are some times plural but it is preferable if the entity names are singular. This format transforms the table name like PascalCase but also makes the words singular. Thus "user_session" will become "UserSession" and "users" will become "User".
 
 The below will export interfaces with such names as `UserModel` and `LogModel` for tables with names `User` and `Log` respectively.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ Specifies the name that the file should be saved as. Defaults to "Database.ts". 
 
 Specifies the pattern that the exported interface names will take. The token "${table}" will be replaced with the table name. Defaults to "${table}Entity".
 
-This property also supports the special value `PascalCase`. In this case, the table name will be transformed by removing the underscores and adding an converting the words to title case. Thus "user_sessions" would become "UserSessions".
+This property also supports special values that transform the table name according to pre-specified rules. The supported formats are:
+
+- `PascalCase`: in this case, the table name will be transformed by removing the underscores and adding an converting the words to title case. Thus "user_sessions" would become "UserSessions".
+
+- `PascalCaseSingular`: table names are some times plural but it is preferable if the entity names are singular. This format transform the table name like PascalCase but also make the words singular. Thus "user_session" will become "UserSession" and "users" will become "User".
 
 The below will export interfaces with such names as `UserModel` and `LogModel` for tables with names `User` and `Log` respectively.
 

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -91,11 +91,17 @@ exports.getAllTables = getAllTables;
  */
 function generateInterfaceName(name, config) {
     var interfaceNamePattern = config.interfaceNameFormat || '${table}Entity';
-    if (interfaceNamePattern === 'PascalCase') {
+    if (interfaceNamePattern.indexOf('PascalCase') === 0) {
         return name.split('_').map(function (s) {
             if (!s.length)
                 return s;
-            return s[0].toUpperCase() + s.substr(1).toLowerCase();
+            if (interfaceNamePattern === 'PascalCase') {
+                return s[0].toUpperCase() + s.substr(1).toLowerCase();
+            }
+            else if (interfaceNamePattern === 'PascalCaseSingular') {
+                var hasS = s[s.length - 1] === 's';
+                return s[0].toUpperCase() + s.substr(1, s.length - (hasS ? 2 : 1)).toLowerCase();
+            }
         }).join('');
     }
     return interfaceNamePattern.replace('${table}', name.replace(/ /g, '_'));

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -91,6 +91,13 @@ exports.getAllTables = getAllTables;
  */
 function generateInterfaceName(name, config) {
     var interfaceNamePattern = config.interfaceNameFormat || '${table}Entity';
+    if (interfaceNamePattern === 'PascalCase') {
+        return name.split('_').map(function (s) {
+            if (!s.length)
+                return s;
+            return s[0].toUpperCase() + s.substr(1).toLowerCase();
+        }).join('');
+    }
     return interfaceNamePattern.replace('${table}', name.replace(/ /g, '_'));
 }
 exports.generateInterfaceName = generateInterfaceName;

--- a/src/TableTasks.spec.ts
+++ b/src/TableTasks.spec.ts
@@ -26,6 +26,13 @@ describe('TableTasks', () => {
         const result = MockTableTasks.generateInterfaceName('n a m e', mockConfig)
         expect(result).toBe('n_a_m_eEntity')
       })
+      it('should convert to PascalCase', () => {
+        const mockConfig = {
+          interfaceNameFormat: 'PascalCase'
+        }
+        expect(MockTableTasks.generateInterfaceName('name_test', mockConfig)).toBe('NameTest')
+        expect(MockTableTasks.generateInterfaceName('_special_case', mockConfig)).toBe('SpecialCase')
+      })
     })
   
   })

--- a/src/TableTasks.spec.ts
+++ b/src/TableTasks.spec.ts
@@ -33,6 +33,13 @@ describe('TableTasks', () => {
         expect(MockTableTasks.generateInterfaceName('name_test', mockConfig)).toBe('NameTest')
         expect(MockTableTasks.generateInterfaceName('_special_case', mockConfig)).toBe('SpecialCase')
       })
+      it('should convert to PascalCaseSingular', () => {
+        const mockConfig = {
+          interfaceNameFormat: 'PascalCaseSingular'
+        }
+        expect(MockTableTasks.generateInterfaceName('user_sessions', mockConfig)).toBe('UserSession')
+        expect(MockTableTasks.generateInterfaceName('users', mockConfig)).toBe('User')
+      })
     })
   
   })

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -36,5 +36,11 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
  */
 export function generateInterfaceName (name: string, config: Config): string {
   const interfaceNamePattern = config.interfaceNameFormat || '${table}Entity'
+  if (interfaceNamePattern === 'PascalCase') {
+    return name.split('_').map(s => {
+      if (!s.length) return s;
+      return s[0].toUpperCase() + s.substr(1).toLowerCase();
+    }).join('');
+  }
   return interfaceNamePattern.replace('${table}', name.replace(/ /g, '_'))
 }

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -36,10 +36,15 @@ export async function getAllTables (db: knex, config: Config): Promise<Table[]> 
  */
 export function generateInterfaceName (name: string, config: Config): string {
   const interfaceNamePattern = config.interfaceNameFormat || '${table}Entity'
-  if (interfaceNamePattern === 'PascalCase') {
+  if (interfaceNamePattern.indexOf('PascalCase') === 0) {
     return name.split('_').map(s => {
       if (!s.length) return s;
-      return s[0].toUpperCase() + s.substr(1).toLowerCase();
+      if (interfaceNamePattern === 'PascalCase') {
+        return s[0].toUpperCase() + s.substr(1).toLowerCase();
+      } else if (interfaceNamePattern === 'PascalCaseSingular') {
+        const hasS = s[s.length - 1] === 's';
+        return s[0].toUpperCase() + s.substr(1, s.length - (hasS ? 2 : 1)).toLowerCase();
+      }
     }).join('');
   }
   return interfaceNamePattern.replace('${table}', name.replace(/ /g, '_'))


### PR DESCRIPTION
The current `interfaceNameFormat` config property allows transforming the table name into the interface name. However currently some transformations are not possible, in particular those that change the case of the word.

This pull request adds the special transformation "PascalCase", which allows transforming table names all lowercase separated by underscore to PascalCase. For example, `user_sessions` will be transformed to `UserSessions`.