### PR TITLE
Added support for config property "excludedTables"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ const definitions = await sqlts.toTypeScript(config)
 ## Config
 
 The configuration extends the [knex configuration](http://knexjs.org/#Installation-client) with some additional properties for table filtering and type overriding.
+
 ### tables
 
 Filter the tables to include only those specified.
@@ -102,6 +103,18 @@ Filter the tables to include only those specified.
   "dialect": "...",
   "connection": {},
   "tables": ["Table1", "Table2"]
+}
+```
+
+### excludedTables
+
+Filter the tables to exclude those specified.
+
+```json
+{
+  "dialect": "...",
+  "connection": {},
+  "excludedTables": ["knex_migrations", "knex_migrations_lock", "android_metadata"]
 }
 ```
 

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -57,6 +57,11 @@ function getAllTables(db, config) {
                     return [4 /*yield*/, adapter.getAllTables(db, config.schemas || [])];
                 case 1:
                     allTables = _a.sent();
+                    if (config.excludedTables && config.excludedTables.length) {
+                        allTables = allTables.filter(function (table) {
+                            return config.excludedTables.indexOf(table.name) < 0;
+                        });
+                    }
                     return [4 /*yield*/, Promise.all(allTables.map(function (table) { return __awaiter(_this, void 0, void 0, function () {
                             var _a;
                             return __generator(this, function (_b) {

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -8,6 +8,7 @@ import * as knex from 'knex';
  */
 export interface Config extends knex.Config {
     tables?: string[];
+    excludedTables?: string[];
     filename?: string;
     interfaceNameFormat?: string;
     schemaAsNamespace?: boolean;

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -57,7 +57,7 @@ var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
                 fileName = (config.filename || 'Database') + ".ts";
                 outFile = path.join(process.cwd(), fileName);
                 fs.writeFileSync(outFile, output);
-                console.log("Definition file written as " + outFile + ".");
+                console.log("Definition file written as " + outFile);
                 return [2 /*return*/];
         }
     });

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -15,7 +15,12 @@ import * as TableSubTasks from './TableSubTasks'
  */
 export async function getAllTables (db: knex, config: Config): Promise<Table[]> {
   const adapter = AdapterFactory.buildAdapter(config)
-  const allTables = await adapter.getAllTables(db, config.schemas || [])
+  let allTables = await adapter.getAllTables(db, config.schemas || [])
+  if (config.excludedTables && config.excludedTables.length) {
+    allTables = allTables.filter(table => {
+      return config.excludedTables.indexOf(table.name) < 0;
+    });
+  }
   const tables =  await Promise.all(allTables.map(async table => ({
     columns: await ColumnTasks.getColumnsForTable(db, table, config),
     name: table.name,

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -7,8 +7,9 @@ import * as knex from 'knex';
  * @interface Config
  * @extends {knex.Config}
  */
-export interface Config extends knex.Config { 
+export interface Config extends knex.Config {
   tables?: string[],
+  excludedTables?: string[],
   filename?: string,
   interfaceNameFormat?: string,
   schemaAsNamespace?: boolean,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,5 +19,5 @@ const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Config
   const fileName = `${config.filename || 'Database'}.ts`
   const outFile = path.join(process.cwd(), fileName)
   fs.writeFileSync(outFile, output)
-  console.log(`Definition file written as ${outFile}.`)
+  console.log(`Definition file written as ${outFile}`)
 })()


### PR DESCRIPTION
Currently the config allows you to specify what tables should be included in generated types. However in some cases you might want to include *all* the tables, *except* a few system ones. This new property `excludedTables` allows doing this by specifying a list of tables that should be excluded.

(Note: I also made a small change - I've removed the "." after the generate file path so that it can be more easily copied and pasted or clicked on from the terminal)