### PR TITLE
Allow avoid optional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ Determines the casing for column names before being passed into the name generat
 }
 ```
 
+### avoidOptionals
+
+Avoid using TypeScript optionals (?) for columns with default value. Defaults to `false`.
+
+```json
+{
+  "dialect": "...",
+  "connection": {},
+  "avoidOptionals": "camel"
+}
+```
+
 ### singularTableNames
 
 Removes the "s" from the end of table names before being passed into the name generator. Defaults `false`.

--- a/src/ColumnTasks.ts
+++ b/src/ColumnTasks.ts
@@ -22,7 +22,7 @@ export async function getColumnsForTable (db: knex, table: TableDefinition, conf
     nullable: c.isNullable,
     name: SharedTasks.convertCase(c.name, config.columnNameCasing),
     type: c.type,
-    optional: c.isOptional
+    optional: config.avoidOptionals ? false : c.isOptional
   } as Column))
 }
 /**

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -14,6 +14,7 @@ export interface Config extends knex.Config {
   interfaceNameFormat?: string,
   tableNameCasing?: 'pascal' | 'camel',
   columnNameCasing?: 'pascal' | 'camel',
+  avoidOptionals?: boolean,
   singularTableNames?: boolean
   schemaAsNamespace?: boolean,
   schemas?: string[],


### PR DESCRIPTION
Hello!
Avoiding optionals allows to use generated types for example in [`knex<Table>("table")`](http://knexjs.org/#Builder-knex) or as return type of `select *`.
I can already do it by providing custom template but to have parameter will be better.
Thank you for your work!