### PR TITLE
Sort type definitions returned by `DatabaseTasks.stringifyDatabase`

### DIFF
--- a/src/DatabaseTasks.ts
+++ b/src/DatabaseTasks.ts
@@ -18,6 +18,7 @@ export function stringifyDatabase (database: Database, config: Config): string {
   if (config.template !== undefined)
     template = fs.readFileSync(config.template, 'utf-8')
   const compiler = handlebars.compile(template)
+  database.tables.sort((tableA, tableB) => tableA.name.localeCompare(tableB.name));
   const grouped : {[key:string]: Table[]} = {}
   for (let t of database.tables) {
     if (grouped[t.schema] === undefined) {


### PR DESCRIPTION
Hi there,

The order of the tables is not declared in pg `Adapter`.  This causes the server to return tables in different orders over time and different computers, which creates false-diffs in source control management and merge pain when collaborating.

This PR sorts `database.tables` alphabetically by name right before they are grouped together. 
 This should prevent the false-diffs in SCM.