### PR TITLE
Fix: Adds peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,30 @@
     "pretest": "tsc -p tsconfig.test.json",
     "test": "jasmine ./__test/{**,}/*.spec.js"
   },
+  "peerDependencies": {
+    "mssql": "^6.2.0",
+    "mysql": "^2.18.1",
+    "mysql2": "^2.1.0",
+    "pg": "^8.0.3",
+    "sqlite3": "^4.1.1"
+  },
+  "peerDependenciesMeta": {
+    "mssql": {
+      "optional": true
+    },
+    "mysql": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    },
+    "sqlite3": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "handlebars": "^4.1.2",
     "knex": "^0.20.4",


### PR DESCRIPTION
This PR specifies peerDependencies of dependencies that are intended for the user to satisfy. This is required for pnp module resolution to function (yarn pnp, yarn berry - like in the PR for dependency knex https://github.com/knex/knex/pull/3081). Without this this module doesn't work with yarn pnp (as the db driver cannot be required).

nb; nice module, it took me a few tries to find it but its great :smile: 