### PR TITLE
Adds "writeMode" (vs readMode)

### DIFF
--- a/dist/AdapterFactory.js
+++ b/dist/AdapterFactory.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildAdapter = void 0;
 /**
  * Returns an AdapterInterface that matches the dialect.
  *
@@ -9,7 +10,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 function buildAdapter(config) {
     var _a, _b;
-    var dialect = (_a = config.dialect, (_a !== null && _a !== void 0 ? _a : config.client.toString()));
+    var dialect = (_a = config.dialect) !== null && _a !== void 0 ? _a : config.client.toString();
     // Use aliases from knex.
     var aliases = {
         'pg': 'postgres',
@@ -18,7 +19,7 @@ function buildAdapter(config) {
     };
     var adapter = null;
     try {
-        adapter = require("./Adapters/" + (_b = aliases[dialect], (_b !== null && _b !== void 0 ? _b : dialect)));
+        adapter = require("./Adapters/" + ((_b = aliases[dialect]) !== null && _b !== void 0 ? _b : dialect));
     }
     catch (err) {
         throw new Error("Unable to find adapter for dialect '" + dialect + "'.");

--- a/dist/Adapters/postgres.js
+++ b/dist/Adapters/postgres.js
@@ -130,7 +130,7 @@ var default_1 = /** @class */ (function () {
                             name: c.name,
                             type: c.typcategory == "E" && config.schemaAsNamespace ? c.enumSchema + "." + c.enumType : c.enumType,
                             isNullable: !c.notNullable,
-                            isOptional: c.hasDefault,
+                            isOptional: config.writeMode && c.hasDefault,
                             isEnum: c.typcategory == "E"
                         }); })];
                 }

--- a/dist/ColumnSubTasks.js
+++ b/dist/ColumnSubTasks.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateFullColumnName = void 0;
 /**
  * Generates the full column name comprised of the table, schema and column.
  *

--- a/dist/ColumnTasks.js
+++ b/dist/ColumnTasks.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.convertType = exports.getColumnsForTable = void 0;
 var AdapterFactory = require("./AdapterFactory");
 var TypeMap_1 = require("./TypeMap");
 var ColumnSubTasks = require("./ColumnSubTasks");

--- a/dist/DatabaseFactory.js
+++ b/dist/DatabaseFactory.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildDatabase = void 0;
 var knex = require("knex");
 var TableTasks = require("./TableTasks");
 var EnumTasks = require("./EnumTasks");

--- a/dist/DatabaseTasks.js
+++ b/dist/DatabaseTasks.js
@@ -11,6 +11,7 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.decorateDatabase = exports.stringifyDatabase = void 0;
 var TableTasks = require("./TableTasks");
 var handlebars = require("handlebars");
 var fs = require("fs");

--- a/dist/EnumTasks.js
+++ b/dist/EnumTasks.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAllEnums = void 0;
 var AdapterFactory = require("./AdapterFactory");
 function getAllEnums(db, config) {
     return __awaiter(this, void 0, void 0, function () {

--- a/dist/SharedTasks.js
+++ b/dist/SharedTasks.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.convertCase = void 0;
 /**
  * Converts the casing of a string.
  *

--- a/dist/TableSubTasks.js
+++ b/dist/TableSubTasks.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getExtends = exports.getAdditionalProperties = void 0;
 /**
  * Returns the additional properties to add to the interface.
  *

--- a/dist/TableTasks.js
+++ b/dist/TableTasks.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateInterfaceName = exports.getAllTables = void 0;
 var AdapterFactory = require("./AdapterFactory");
 var ColumnTasks = require("./ColumnTasks");
 var TableSubTasks = require("./TableSubTasks");

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -16,6 +16,7 @@ export interface Config extends knex.Config {
     columnNameCasing?: 'pascal' | 'camel';
     singularTableNames?: boolean;
     schemaAsNamespace?: boolean;
+    writeMode?: boolean;
     schemas?: string[];
     template?: string;
     typeMap?: {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -55,8 +55,8 @@ var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
             case 0: return [4 /*yield*/, index_1.default.toTypeScript(config)];
             case 1:
                 output = _c.sent();
-                fileName = (_a = config.filename, (_a !== null && _a !== void 0 ? _a : 'Database')) + ".ts";
-                directory = (_b = config.folder, (_b !== null && _b !== void 0 ? _b : '.'));
+                fileName = ((_a = config.filename) !== null && _a !== void 0 ? _a : 'Database') + ".ts";
+                directory = (_b = config.folder) !== null && _b !== void 0 ? _b : '.';
                 outFile = path.join(process.cwd(), directory, fileName);
                 fs.writeFileSync(outFile, output);
                 console.log("Definition file written as " + outFile);

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.toTypeScript = exports.fromObject = exports.toObject = void 0;
 var DatabaseFactory = require("./DatabaseFactory");
 var DatabaseTasks = require("./DatabaseTasks");
 /**

--- a/src/Adapters/postgres.ts
+++ b/src/Adapters/postgres.ts
@@ -70,7 +70,7 @@ export default class implements AdapterInterface {
         name: c.name,
         type: c.typcategory == "E" && config.schemaAsNamespace ? `${c.enumSchema}.${c.enumType}` : c.enumType,
         isNullable: !c.notNullable,
-        isOptional: c.hasDefault,
+        isOptional: config.writeMode && c.hasDefault,
         isEnum: c.typcategory == "E"
       }) as ColumnDefinition)
   }

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -17,6 +17,7 @@ export interface Config extends knex.Config {
   columnNameCasing?: 'pascal' | 'camel',
   singularTableNames?: boolean
   schemaAsNamespace?: boolean,
+  writeMode?: boolean,  
   schemas?: string[],
   template?: string,
   typeMap?: {


### PR DESCRIPTION
We have quickly found that its important for us to differentiate write and read types - that is, write types may have some fields as optional because they have defaults however read schemas will always have these fields set. This is normally quite an important field, like an id or timestamp.

My solution for our use case has been:

* add this writeMode flag and to only consider defaults optional when writeMode is set.
* generate types twice, with two interface name formats: '${table}_entity_write' and '${table}_entity'

When used in our codebases we find the read types are the default types used, and write types exist for a short period on a limited number of code paths.

 