### PR TITLE
Mention the schema name for SQLite databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Filter the tables to include only those specified. These must be in the format `
 
 Filter the tables to exclude those specified. These must be in the format `schema.table`. See [interfaceNameFormat](#interfacenameformat) for schema naming conventions.
 
-Excluding a table takes precedence over including it. Specifying a table in both configuration options will exclude it.
+Excluding a table takes precedence over including it. Specifying a table in both configuration options will exclude it. Note that for SQLite the schema is always called `main`, so to refer to a table you would use for example "main.my_table".
 
 ```json
 {


### PR DESCRIPTION
I'm not sure if there's any way to know what the schema name is for SQLite with the current implementation. What I always do is add "console" statement in sql-ts to find out, but it would be better to document it. I believe it's always "main" for SQLite.