### PR TITLE
Fix Buffer type name

### DIFF
--- a/src/TypeMap.ts
+++ b/src/TypeMap.ts
@@ -4,5 +4,5 @@ export default {
   Date: ['datetime', 'timestamp', 'date', 'time', 'timestamp', 'datetime2', 'smalldatetime', 'datetimeoffset'],
   boolean: ['bit', 'boolean', 'bool'],
   Object: ['json', 'TVP'],
-  buffer: ['binary', 'varbinary', 'image', 'UDT']
+  Buffer: ['binary', 'varbinary', 'image', 'UDT']
 }


### PR DESCRIPTION
Resolves TS2304 `Cannot find name 'buffer'. ts(2304)`

Update to reference the `Buffer` class as defined within `@types/node/globals.d.ts`