### PR TITLE
match sqllite version with knex projects version

### DIFF
--- a/dist/TypeMap.d.ts
+++ b/dist/TypeMap.d.ts
@@ -4,6 +4,6 @@ declare const _default: {
     Date: string[];
     boolean: string[];
     Object: string[];
-    buffer: string[];
+    Buffer: string[];
 };
 export default _default;

--- a/dist/TypeMap.js
+++ b/dist/TypeMap.js
@@ -6,5 +6,5 @@ exports.default = {
     Date: ['datetime', 'timestamp', 'date', 'time', 'timestamp', 'datetime2', 'smalldatetime', 'datetimeoffset'],
     boolean: ['bit', 'boolean', 'bool'],
     Object: ['json', 'TVP'],
-    buffer: ['binary', 'varbinary', 'image', 'UDT']
+    Buffer: ['binary', 'varbinary', 'image', 'UDT']
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mysql": "^2.18.1",
     "mysql2": "^2.1.0",
     "pg": "^8.0.3",
-    "sqlite3": "^4.1.1"
+    "sqlite3": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "mssql": {


### PR DESCRIPTION
Knex already uses ^5.0.0 while sql-ts has ^4.1.1 this can lead to dependency hickups.

I ran _yarn run build_ and _yarn run test_ successfully. 