### PR TITLE
isNullable currently broken. The attribute name is mismatched.

### DIFF
--- a/src/Adapters/mysql.ts
+++ b/src/Adapters/mysql.ts
@@ -19,7 +19,7 @@ export default class implements AdapterInterface {
     const sql = `
       SELECT
         column_name as name,
-        is_nullable,
+        is_nullable as isNullable,
         CASE WHEN LOCATE('auto_increment', extra) <> 0 OR COLUMN_DEFAULT IS NOT NULL THEN 1 ELSE 0 END isOptional,
         CASE WHEN EXISTS(
           SELECT NULL FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu


### PR DESCRIPTION
MySQL 8 also brings back attributes in all upper-case...so aliasing fixes both problems...
`IS_NULLABLE` is what is currently being returned, when we when `isNullable` is what is being read.