### PR TITLE
Add `float4` and `float8` data types

### DIFF
--- a/src/TypeMap.ts
+++ b/src/TypeMap.ts
@@ -1,6 +1,6 @@
 export default {
   string: ['nchar', 'nvarchar', 'varchar', 'char', 'tinytext', 'text', 'longtext', 'mediumtext', 'ntext', 'varbinary', 'uuid', 'uniqueidentifier', 'character varying', 'bigint', 'xml'],
-  number: ['tinyint', 'int', 'numeric', 'integer', 'real', 'smallint', 'decimal', 'float', 'double precision', 'double', 'dec', 'fixed', 'year', 'serial', 'bigserial', 'int4', 'money', 'smallmoney'],
+  number: ['tinyint', 'int', 'numeric', 'integer', 'real', 'smallint', 'decimal', 'float', 'float4', 'float8', 'double precision', 'double', 'dec', 'fixed', 'year', 'serial', 'bigserial', 'int4', 'money', 'smallmoney'],
   Date: ['datetime', 'timestamp', 'date', 'time', 'timestamp', 'datetime2', 'smalldatetime', 'datetimeoffset'],
   boolean: ['bit', 'boolean', 'bool'],
   Object: ['json', 'TVP'],


### PR DESCRIPTION
Ran into the problem that postgres columns created as `real` resulted in `any` types in the TS output. Debugging a bit, I noted that sql-ts was receiving `float4` as the column type.