### PR TITLE
Add int2, citext and timestamptz data types to map

### DIFF
--- a/src/TypeMap.ts
+++ b/src/TypeMap.ts
@@ -1,7 +1,7 @@
 export default {
-  string: ['nchar', 'nvarchar', 'varchar', 'char', 'tinytext', 'text', 'longtext', 'mediumtext', 'ntext', 'varbinary', 'uuid', 'uniqueidentifier', 'character varying', 'bigint', 'xml'],
-  number: ['tinyint', 'int', 'numeric', 'integer', 'real', 'smallint', 'decimal', 'float', 'float4', 'float8', 'double precision', 'double', 'dec', 'fixed', 'year', 'serial', 'bigserial', 'int4', 'money', 'smallmoney'],
-  Date: ['datetime', 'timestamp', 'date', 'time', 'timestamp', 'datetime2', 'smalldatetime', 'datetimeoffset'],
+  string: ['nchar', 'nvarchar', 'varchar', 'char', 'tinytext', 'text', 'longtext', 'mediumtext', 'ntext', 'citext', 'varbinary', 'uuid', 'uniqueidentifier', 'character varying', 'bigint', 'xml'],
+  number: ['tinyint', 'int', 'numeric', 'integer', 'real', 'smallint', 'decimal', 'float', 'float4', 'float8', 'double precision', 'double', 'dec', 'fixed', 'year', 'serial', 'bigserial', 'int2', 'int4', 'money', 'smallmoney'],
+  Date: ['datetime', 'timestamp', 'date', 'time', 'timestamptz', 'datetime2', 'smalldatetime', 'datetimeoffset'],
   boolean: ['bit', 'boolean', 'bool'],
   Object: ['json', 'TVP'],
   Buffer: ['binary', 'varbinary', 'image', 'UDT']


### PR DESCRIPTION
I ran into some `any` types, so I realized these Postgres types are missing in the type map. Solved it by overriding them in the config, but it might be nice to add them to the default map. There was a duplicate `timestamp`, so I used that one for `timestamptz`.