### PR TITLE
Add support for custom connection via the knexConnection property

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,18 @@ See the section on templating for more info on how to use the template.
 }
 ```
 
+### knexConnection
+
+Optionally, you may provide an active Knex connection, in which case sql-ts will use it in the build scripts. Additionally sql-ts will not automatically close the connection - your calling code instead should take care of this. When using a custom connection, you must also specify the `dialect` property.
+
+```json
+{
+  "client": "...",
+  "knexConnection": customKnexConnection,
+  "dialect": "sqlite3",
+}
+```
+
 ## Templating
 
 The `template.handlebars` file controls the output of the generated .ts file. You can modify this file and use the `template` config option to specify a custom template file.

--- a/dist/DatabaseFactory.js
+++ b/dist/DatabaseFactory.js
@@ -54,26 +54,30 @@ function buildDatabase(config) {
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
-                    _b.trys.push([0, 3, 4, 5]);
-                    db = knex(config);
+                    if (config.knexConnection && !config.dialect)
+                        throw new Error('"dialect" property must be set when using a custom connection');
+                    _b.label = 1;
+                case 1:
+                    _b.trys.push([1, 4, 5, 6]);
+                    db = config.knexConnection ? config.knexConnection : knex(config);
                     _a = {};
                     return [4 /*yield*/, TableTasks.getAllTables(db, config)];
-                case 1:
+                case 2:
                     _a.tables = _b.sent();
                     return [4 /*yield*/, EnumTasks.getAllEnums(db, config)];
-                case 2:
+                case 3:
                     database = (_a.enums = _b.sent(),
                         _a);
-                    return [3 /*break*/, 5];
-                case 3:
+                    return [3 /*break*/, 6];
+                case 4:
                     err_1 = _b.sent();
                     throw err_1;
-                case 4:
-                    if (db !== undefined) {
+                case 5:
+                    if (db !== undefined && !config.knexConnection) {
                         db.destroy();
                     }
                     return [7 /*endfinally*/];
-                case 5: return [2 /*return*/, database];
+                case 6: return [2 /*return*/, database];
             }
         });
     });

--- a/dist/Typings.d.ts
+++ b/dist/Typings.d.ts
@@ -31,6 +31,7 @@ export interface Config extends knex.Config {
     extends?: {
         [key: string]: string;
     };
+    knexConnection?: knex;
 }
 /**
  * The JSON definition of a column for importing and exporting.

--- a/dist/template.handlebars
+++ b/dist/template.handlebars
@@ -5,14 +5,14 @@ export interface {{interfaceName}} {{#if extends}}extends {{extends}} {{/if}}{
   {{prop}}
   {{/each}}
   {{#each columns}}
-  "{{propertyName}}"{{#if optional}}?{{/if}}: {{propertyType}} {{#if nullable}}| null {{/if}}
+  '{{propertyName}}'{{#if optional}}?{{/if}}: {{propertyType}}{{#if nullable}} | null{{/if}};
   {{/each}}
 }
 {{/each}}
 {{#each enums as |enum|}}
 export enum {{convertedName}} {
 {{#each values as |value|}}
-  {{value.convertedKey}} = "{{value.value}}",
+  {{value.convertedKey}} = '{{value.value}}',
 {{/each}}
 }
 {{/each}}

--- a/src/DatabaseFactory.spec.ts
+++ b/src/DatabaseFactory.spec.ts
@@ -48,5 +48,39 @@ describe('DatabaseFactory', () => {
         done()
       }
     })
+    it('should allow using a custom Knex connection', async (done) => {
+      const mockKnex = {
+        destroy: jasmine.createSpy('knex.destroy')
+      }
+
+      MockDatabaseFactory.__set__({
+        TableTasks: {
+          getAllTables: jasmine.createSpy('getAllTables').and.returnValue(Promise.resolve(['table1', 'table2']))
+        },
+        EnumTasks: {
+          getAllEnums: jasmine.createSpy('getAllEnums').and.returnValue(Promise.resolve(['enum1', 'enum2']))
+        }
+      })
+
+      await MockDatabaseFactory.buildDatabase({
+        knexConnection:  mockKnex,
+        dialect: 'sqlite3',
+      }) as any
+
+      expect(mockKnex.destroy).not.toHaveBeenCalled()
+
+      let hasThrown = false;
+      try {
+        await MockDatabaseFactory.buildDatabase({
+          knexConnection:  mockKnex,
+        })
+      } catch (error) {
+        hasThrown = true;
+      }
+
+      expect(hasThrown).toBe(true);
+
+      done()
+    })
   })
 })

--- a/src/DatabaseFactory.ts
+++ b/src/DatabaseFactory.ts
@@ -14,8 +14,11 @@ import * as EnumTasks from './EnumTasks'
 export async function buildDatabase (config: Config): Promise<Database> {
   let database: Database
   let db: knex
+
+  if (config.knexConnection && !config.dialect) throw new Error('"dialect" property must be set when using a custom connection');
+  
   try {
-    db = knex(config)
+    db = config.knexConnection ? config.knexConnection : knex(config)
     database = {
       tables: await TableTasks.getAllTables(db, config),
       enums: await EnumTasks.getAllEnums(db, config)
@@ -25,7 +28,7 @@ export async function buildDatabase (config: Config): Promise<Database> {
     throw err
   }
   finally {
-    if (db !== undefined) {
+    if (db !== undefined && !config.knexConnection) {
       db.destroy()
     }
   }

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -31,7 +31,8 @@ export interface Config extends knex.Config {
   },
   extends?: { 
     [key: string]: string
-  }
+  },
+  knexConnection?: knex,
 } 
 
 /**


### PR DESCRIPTION
Currently sql-ts always creates a new connection and destroy it at the end of the script, however in some cases you might already have a connection and would prefer to manage it yourself.

I had this issue for example when running test units - I wanted to get the database schema multiple times during the test and it had to be done from the active connection.

So this pull request adds support for this by adding a new `knexConnection` config variable. When set, the sql-ts scripts will use this, and will also not automatically close the connection.

I had some issues getting it to work because some functions expects a client or a dialect to be set. So I made it required to set the dialect property when providing a Knex connection. I think that makes sense since the connection is live and it's not possible (I believe) to get the dialect from it.

Also there was a few extra build artefacts after running `npm run build`. I'm not sure if they should be included in the commit so let me know if I should remove them.