### PR TITLE
Separate row insertion types from row selection types

### DIFF
--- a/dist/Adapters/postgres.js
+++ b/dist/Adapters/postgres.js
@@ -117,7 +117,7 @@ var default_1 = /** @class */ (function () {
                             name: c.name,
                             type: c.typcategory == "E" && config.schemaAsNamespace ? c.enumschema + "." + c.enumtype : c.enumtype,
                             isNullable: !c.notnullable,
-                            isOptional: c.hasdefault,
+                            isOptional: !c.notnullable || c.hasdefault,
                             isEnum: c.typcategory == "E",
                             isPrimaryKey: c.isprimarykey == 1
                         }); })];

--- a/dist/DatabaseTasks.js
+++ b/dist/DatabaseTasks.js
@@ -27,22 +27,21 @@ var ColumnTasks = require("./ColumnTasks");
  * @returns A TypeScript definition, optionally wrapped in a namespace.
  */
 function stringifyDatabase(database, config) {
-    var template = fs.readFileSync(path.join(__dirname, './template.handlebars'), 'utf-8');
-    if (config.template !== undefined) {
-        template = fs.readFileSync(config.template, 'utf-8');
-    }
+    var _a;
+    var templatePath = (_a = config.template) !== null && _a !== void 0 ? _a : path.join(__dirname, './template.handlebars');
+    var template = fs.readFileSync(templatePath, 'utf-8');
     var compiler = handlebars.compile(template);
     database.tables.sort(function (tableA, tableB) { return tableA.name.localeCompare(tableB.name); });
     var grouped = {};
-    for (var _i = 0, _a = database.tables; _i < _a.length; _i++) {
-        var t = _a[_i];
+    for (var _i = 0, _b = database.tables; _i < _b.length; _i++) {
+        var t = _b[_i];
         if (grouped[t.schema] === undefined) {
             grouped[t.schema] = { tables: [], enums: [] };
         }
         grouped[t.schema].tables.push(t);
     }
-    for (var _b = 0, _c = database.enums; _b < _c.length; _b++) {
-        var e = _c[_b];
+    for (var _c = 0, _d = database.enums; _c < _d.length; _c++) {
+        var e = _d[_c];
         if (grouped[e.schema] === undefined) {
             grouped[e.schema] = { tables: [], enums: [] };
         }

--- a/dist/template.handlebars
+++ b/dist/template.handlebars
@@ -5,14 +5,22 @@ export interface {{interfaceName}} {{#if extends}}extends {{extends}} {{/if}}{
   {{prop}}
   {{/each}}
   {{#each columns}}
-  "{{propertyName}}"{{#if optional}}?{{/if}}: {{propertyType}} {{#if nullable}}| null {{/if}}
+  '{{propertyName}}': {{propertyType}}{{#if nullable}} | null{{/if}};
+  {{/each}}
+}
+export interface Create{{interfaceName}} {{#if extends}}extends {{extends}} {{/if}}{
+  {{#each additionalProperties as |prop|}}
+  {{prop}}
+  {{/each}}
+  {{#each columns}}
+  '{{propertyName}}'{{#if optional}}?{{/if}}: {{propertyType}}{{#if nullable}} | null{{/if}};
   {{/each}}
 }
 {{/each}}
 {{#each enums as |enum|}}
 export enum {{convertedName}} {
 {{#each values as |value|}}
-  {{value.convertedKey}} = "{{value.value}}",
+  {{value.convertedKey}} = '{{value.value}}',
 {{/each}}
 }
 {{/each}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rmp135/sql-ts",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Adapters/postgres.ts
+++ b/src/Adapters/postgres.ts
@@ -3,7 +3,7 @@ import { AdapterInterface, TableDefinition, ColumnDefinition, EnumDefinition } f
 import { Config } from '..'
 
 export default class implements AdapterInterface {
-  async getAllEnums(db: knex, config: Config): Promise<EnumDefinition[]> {
+  async getAllEnums (db: knex, config: Config): Promise<EnumDefinition[]> {
     const query = db('pg_type')
       .select('pg_namespace.nspname AS schema')
       .select('pg_type.typname AS name')
@@ -12,7 +12,7 @@ export default class implements AdapterInterface {
       .join('pg_namespace', 'pg_namespace.oid', 'pg_type.typnamespace')
     if (config.schemas?.length > 0)
       query.whereIn('pg_namespace.nspname', config.schemas)
-    
+
     const enums: { schema: string, name: string, value: string }[] = await query
     const foundEnums: {[key: string]: EnumDefinition} = {}
     function getValues(schema: string, name: string) {
@@ -30,7 +30,7 @@ export default class implements AdapterInterface {
     }
     return Object.values(foundEnums)
   }
-  async getAllTables(db: knex, schemas: string[]): Promise<TableDefinition[]> {
+  async getAllTables (db: knex, schemas: string[]): Promise<TableDefinition[]> {
     const query = db('pg_tables')
     .select('schemaname AS schema')
     .select('tablename AS name')
@@ -47,7 +47,7 @@ export default class implements AdapterInterface {
       query.whereIn('schemaname', schemas)
     return await query
   }
-  async getAllColumns(db: knex, config: Config, table: string, schema: string): Promise<ColumnDefinition[]> {
+  async getAllColumns (db: knex, config: Config, table: string, schema: string): Promise<ColumnDefinition[]> {
     const sql = `
       SELECT
         typns.nspname AS enumSchema,
@@ -79,7 +79,7 @@ export default class implements AdapterInterface {
         name: c.name,
         type: c.typcategory == "E" && config.schemaAsNamespace ? `${c.enumschema}.${c.enumtype}` : c.enumtype,
         isNullable: !c.notnullable,
-        isOptional: c.hasdefault,
+        isOptional: !c.notnullable || c.hasdefault,
         isEnum: c.typcategory == "E",
         isPrimaryKey: c.isprimarykey == 1
       }) as ColumnDefinition)

--- a/src/DatabaseTasks.ts
+++ b/src/DatabaseTasks.ts
@@ -8,17 +8,15 @@ import * as ColumnTasks from './ColumnTasks';
 
 /**
  * Converts a Database definition to TypeScript.
- * 
+ *
  * @export
  * @param {Database} database The Database definition.
  * @param {Config} config The configuration to use.
  * @returns A TypeScript definition, optionally wrapped in a namespace.
  */
 export function stringifyDatabase (database: DecoratedDatabase, config: Config): string {
-  let template = fs.readFileSync(path.join(__dirname, './template.handlebars'), 'utf-8')
-  if (config.template !== undefined) {
-    template = fs.readFileSync(config.template, 'utf-8')
-  }
+  const templatePath = config.template ?? path.join(__dirname, './template.handlebars')
+  const template = fs.readFileSync(templatePath, 'utf-8')
   const compiler = handlebars.compile(template)
   database.tables.sort((tableA, tableB) => tableA.name.localeCompare(tableB.name));
   const grouped : {[key:string]: { tables: Table[], enums: DecoratedEnum[]}} = {}
@@ -48,7 +46,7 @@ export function stringifyDatabase (database: DecoratedDatabase, config: Config):
  * @param {Config} config The configuration to use.
  * @returns The decorated database definition.
  */
-export function decorateDatabase(database: Database, config: Config): DecoratedDatabase {
+export function decorateDatabase (database: Database, config: Config): DecoratedDatabase {
   return {
     enums: database.enums.map(e => {
       return {
@@ -74,6 +72,6 @@ export function decorateDatabase(database: Database, config: Config): DecoratedD
           }
         })
       }
-    })  
+    })
   }
 }

--- a/src/template.handlebars
+++ b/src/template.handlebars
@@ -5,6 +5,14 @@ export interface {{interfaceName}} {{#if extends}}extends {{extends}} {{/if}}{
   {{prop}}
   {{/each}}
   {{#each columns}}
+  '{{propertyName}}': {{propertyType}}{{#if nullable}} | null{{/if}};
+  {{/each}}
+}
+export interface Create{{interfaceName}} {{#if extends}}extends {{extends}} {{/if}}{
+  {{#each additionalProperties as |prop|}}
+  {{prop}}
+  {{/each}}
+  {{#each columns}}
   '{{propertyName}}'{{#if optional}}?{{/if}}: {{propertyType}}{{#if nullable}} | null{{/if}};
   {{/each}}
 }


### PR DESCRIPTION
Issue: the existing generated types are not strict for fields with a default. For example, consider a `users` table with a generated non-nullable uid. The current generated type is:

```ts
export interface UsersRow {
  uid?: string;
}
```

This causes problems when `strictNullChecks` is enabled, because now the type suggests that a row fetched from your database might not have a `uid`! The solution presented in this PR is to have separate types for row selection and row insertion.

This PR has 3 major changes:
1. Rename the existing generated type for a table (from e.g. `UsersRow` to `CreateUsersRow`
  - this is technically a breaking change, but I'd suggest that most usages of this type actually will want to use the new one, since there are usually relatively few callsites for row insertion. 
2. Add a new type with the old name (e.g. `UsersRow`), importantly with stricter types for fields with defaults
3. (in postgres) makes nullable columns have a default as well