### PR TITLE
Fix #82 - Remove line that parses number into string

### DIFF
--- a/src/SharedTasks.ts
+++ b/src/SharedTasks.ts
@@ -10,20 +10,17 @@ import { camelCase, pascalCase } from 'change-case'
  * @returns The converted name.
  */
 export function convertCase (name: string, caseType: string) {
-  /** removes any number at the beginning of the string */
-  const scapedName = name.replace(/^([0-9]+)/g, '');
-
   switch (caseType) {
     case 'pascal':
-      return pascalCase(scapedName)
+      return pascalCase(name)
     case 'camel':
-      return camelCase(scapedName)
+      return camelCase(name)
     case 'lower':
-      return scapedName.toLowerCase()
+      return name.toLowerCase()
     case 'upper':
-      return scapedName.toUpperCase()
+      return name.toUpperCase()
     default:
-      return scapedName
+      return name
   }
 }
 

--- a/src/specs/SharedTasks.spec.ts
+++ b/src/specs/SharedTasks.spec.ts
@@ -32,10 +32,6 @@ describe('SharedTasks', () => {
       const result = SharedTasks.convertCase('TableNameWithUppercase', 'camel')
       expect(result).toEqual('tableNameWithUppercase')
     })
-    it('should should remove numbers from the start', () => {
-      const result = SharedTasks.convertCase('1Ta2bLeNaM3', 'camel')
-      expect(result).toEqual('ta2bLeNaM3')
-    })
   })
   describe('resolveAdapterName', () => {
     it('should resolve the same adapter name if no matching dialect alias exists', () => {


### PR DESCRIPTION
Regarding issue #82 I've removed `replace` method that removes number from column property name.
Also I've removed the test code that tested the removing number part of the code.