### PR TITLE
feat(postgres): support generated columns and identities

### DIFF
--- a/src/Adapters/postgres.ts
+++ b/src/Adapters/postgres.ts
@@ -69,7 +69,7 @@ export default class implements AdapterInterface {
         pg_namespace.nspname AS schema,
         pg_catalog.format_type(pg_attribute.atttypid, null) as type,
         pg_attribute.attnotnull AS notNullable,
-        pg_attribute.atthasdef AS hasDefault,
+        pg_attribute.atthasdef OR pg_attribute.attidentity <> '' AS hasDefault,
         pg_class.relname AS table,
         pg_type.typcategory AS typcategory,
         CASE WHEN EXISTS (


### PR DESCRIPTION
attidentity: If a zero byte (''), then not an identity column. Otherwise, a = generated always, d = generated by default.

https://www.postgresql.org/docs/10/catalog-pg-attribute.html

===

```sql
CREATE TABLE test
(
  sequence      INTEGER GENERATED BY DEFAULT AS IDENTITY CONSTRAINT pkey PRIMARY KEY,
  generated     INTEGER GENERATED ALWAYS AS sequence + 1 STORED,
);
```

```ts
// before

interface test {
  sequence: number
  generated: number
}

// after 
interface test {
  sequence?: number
  generated?: number
}
```