### PR TITLE
Improve SQLite adapter correctness.

### DIFF
--- a/src/Adapters/sqlite.ts
+++ b/src/Adapters/sqlite.ts
@@ -6,7 +6,7 @@ export default class implements AdapterInterface {
   getAllEnums(db: Knex, config: Config): Promise<EnumDefinition[]> {
     return Promise.resolve([])
   }
-  
+
   async getAllTables(db: Knex, schemas: string[]): Promise<TableDefinition[]> {
     return (await db('sqlite_master')
     .select('tbl_name AS name')
@@ -17,14 +17,14 @@ export default class implements AdapterInterface {
 
   async getAllColumns(db: Knex, config: Config, table: string, schema: string): Promise<ColumnDefinition[]> {
     return (await db.raw(`pragma table_info(${table})`))
-    .map((c: { name: string, type: string, notnull: 0 | 1, dflt_value: any, pk: 0 | 1 }) => (
+    .map((c: { name: string, type: string, notnull: 0 | 1, dflt_value: string | null, pk: number }) => (
       {
         name: c.name,
         nullable: c.notnull === 0,
         type: (c.type.includes('(') ? c.type.split('(')[0] : c.type).toLowerCase(),
-        optional: c.dflt_value != null || c.pk == 1 || c.notnull === 0,
+        optional: c.dflt_value !== null || c.notnull === 0,
         isEnum: false,
-        isPrimaryKey: c.pk == 1
+        isPrimaryKey: c.pk !== 0
       } as ColumnDefinition
     ))
   }

--- a/src/specs/Adapters/sqlite.spec.ts
+++ b/src/specs/Adapters/sqlite.spec.ts
@@ -28,7 +28,7 @@ describe('sqlite', () => {
           name: 'name1',
           notnull: 0,
           type: 'type(123)',
-          dflt: null,
+          dflt_value: null,
           pk: 0
         }
       ]
@@ -56,7 +56,7 @@ describe('sqlite', () => {
           name: 'name1',
           notnull: 0,
           type: 'type',
-          dflt: 1234,
+          dflt_value: '1234',
           pk: 0
         }
       ]
@@ -84,8 +84,15 @@ describe('sqlite', () => {
           name: 'name1',
           notnull: 0,
           type: 'type',
-          dflt: null,
+          dflt_value: null,
           pk: 1
+        },
+        {
+          name: 'name2',
+          notnull: 1,
+          type: "type",
+          dflt_value: null,
+          pk: 2,
         }
       ]
       const mockRaw = jasmine.createSpy('raw').and.returnValue(mockTables)
@@ -103,6 +110,14 @@ describe('sqlite', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true
+        },
+        {
+          name: 'name2',
+          nullable: false,
+          type: 'type',
+          optional: false,
+          isEnum: false,
+          isPrimaryKey: true
         }
       ])
     })
@@ -112,7 +127,7 @@ describe('sqlite', () => {
           name: 'name1',
           notnull: 1,
           type: 'type',
-          dflt: null,
+          dflt_value: null,
           pk: 0
         }
       ]
@@ -140,7 +155,7 @@ describe('sqlite', () => {
           name: 'name1',
           notnull: 0,
           type: 'type(123,33)',
-          dflt: null,
+          dflt_value: null,
           pk: 1
         }
       ]


### PR DESCRIPTION
Hi there!

I've been trying to use this library as [schemats](https://github.com/sweetiq/schemats) doesn't support SQLite. Nice job!

I found a couple of issues with the SQLite adapter, though.

The first one is the fact that `PRAGMA table_info(<table>)` column `pk` type is `INTEGER`, not a "boolean" (`0 | 1`), with the number representing [the index of the column in the primary key for columns that are part of the primary key](https://www.sqlite.org/pragma.html#pragma_table_info). I've corrected the types and the code to correctly detect primary keys with index greater than 0.

Second, a column being part of a primary key doesn't mean that it's value is optional. A column with [`AUTOINCREMENT`](https://www.sqlite.org/autoinc.html) is, but checking for that [requires data to have been inserted in the table](https://stackoverflow.com/a/20983822), so it's not realiable. 
A table with an `INTEGER` column as unique primary key would usually get that column aliased to [`rowid`](https://www.sqlite.org/rowidtable.html), which is `AUTOINCREMENT`, but this isn't true if we use `WITHOUT ROWID`, so checking for a single `INTEGER PRIMARY KEY` is not a solution.
In the end I think it's more robust to omit this checking.

Finally, the correct type for the column `dflt_value` is not `any`, but `string | null`. It has the default value as it was written (i.e. a literal string) or `null` if there isn't none. Amusingly, you can create a table `CREATE TABLE foo (bar TEXT NOT NULL DEFAULT NULL)` and it would work! But you would not be able to insert `null`s in it. I've also fixed this property name in the tests.

I've not checked the other adapters for these issues!

Hope this is helpful.