### PR TITLE
Add better mappings for PostgreSQL types.

### DIFF
--- a/src/TypeMap.ts
+++ b/src/TypeMap.ts
@@ -9,7 +9,8 @@ export default {
     Buffer: ['binary', 'varbinary', 'image', 'UDT']
   },
   postgres: {
-    string: ['numeric', 'decimal', 'int8', 'money']
+    string: ['numeric', 'decimal', 'int8', 'money', 'bpchar', 'character_data' ] ,
+    'string[]' : ['_char', '_varchar', '_bpchar', '_character_data']
   },
   mssql: {
     string: ['timestamp']


### PR DESCRIPTION
Occasionally, Postgres does arbitrarily some type conversion.
For example, `char` to `bpchar` → “Blank padded char”.
Query: `SELECT * FROM pg_type WHERE typname ilike '%char%'`
This commit aims to avoid `any` when possible by default.