### PR TITLE
Pass an optional `custom` entry to the handlebar's compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,8 @@ The inputs to this file are as followed.
         }
       ]
     }
-  }
+  },
+  custom : {} , // Attach custom data if needed.
 }
 ```
 

--- a/src/DatabaseTasks.ts
+++ b/src/DatabaseTasks.ts
@@ -40,6 +40,9 @@ export function stringifyDatabase (database: Database, config: Config): string {
   }
   return compiler({
     grouped: template,
+    tables: database.tables,
+    enums: database.enums,
+    custom: database.custom ?? {},
     config
   })
 }

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -61,6 +61,7 @@ export interface Table extends TableDefinition {
 export interface Database {
   tables: Table[]
   enums: Enum[]
+  custom?: Record<string,any>
 }
 
 /**


### PR DESCRIPTION
This addition could be handy for people using the library directly instead of the cli, thus, making `sqlts.fromObject( definitions , config )` more useful.

**Example:**
```js
const config = { /* some config */ };
const definitions = await sqlts.toObject( config );
definitions.custom = { some_array : [ 1 , 2 , 3 ] , version : "1.2.3" , some_info: await getSomeAsyncInfo() };
sqlts.fromObject( definitions , config );
```

Any notes on this @rmp135 ?