### PR TITLE
Pass comparison function when sorting enums

### DIFF
--- a/src/Adapters/postgres.ts
+++ b/src/Adapters/postgres.ts
@@ -32,7 +32,7 @@ export default class implements AdapterInterface {
         values: Object.fromEntries(
           ungroupedEnums
             .filter(e => e.schema == row.schema && e.name == row.name)
-            .sort()
+            .sort((a, b) => a.order - b.order)
             .map(e => [e.value, e.value])
         )
       }))


### PR DESCRIPTION
Your fix to #88 is almost right, but the call to `Array.sort()` is missing the correct comparison function.