### PR TITLE
enabled singularTableNames to fix 'ies' plurals

### DIFF
--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -74,8 +74,12 @@ export function getExtends (tableName: string, schemaName: string, config: Confi
   const interfaceNamePattern = config.interfaceNameFormat
   name = name.replace(/ /g, '_')
   name = SharedTasks.convertCase(name, config.tableNameCasing)
-  if (config.singularTableNames && name[name.length - 1] == "s") {
-    name = name.substr(0, name.length - 1)
+  if (config.singularTableNames) {
+    if(name.match(/ies$/)) {
+     name = name.replace(/ies$/, 'y'); 
+    } else if(name[name.length - 1] == "s") {
+      name = name.substr(0, name.length - 1)
+    }
   }
   return interfaceNamePattern.replace('${table}', name)
 }

--- a/src/TableTasks.ts
+++ b/src/TableTasks.ts
@@ -76,7 +76,7 @@ export function getExtends (tableName: string, schemaName: string, config: Confi
   name = SharedTasks.convertCase(name, config.tableNameCasing)
   if (config.singularTableNames) {
     if(name.match(/ies$/)) {
-     name = name.replace(/ies$/, 'y'); 
+     name = name.replace(/ies$/, 'y')
     } else if(name[name.length - 1] == "s") {
       name = name.substr(0, name.length - 1)
     }

--- a/src/specs/TableTasks.spec.ts
+++ b/src/specs/TableTasks.spec.ts
@@ -101,6 +101,23 @@ describe('TableTasks', () => {
         done()
       })
     })
+    it('should convert to singular with a name ending in "ies"', (done) => {
+      const mockConfig: Config = {
+        interfaceNameFormat: '${table}Name',
+        singularTableNames: true
+      }
+      const mockSharedTasks = {
+        convertCase: jasmine.createSpy('convertCase').and.returnValue('babies')
+      }
+      MockTableTasks.__with__({
+        SharedTasks: mockSharedTasks
+      })(() => {
+        const result = MockTableTasks.generateInterfaceName('babies', mockConfig)
+        expect(mockSharedTasks.convertCase).toHaveBeenCalledWith('babies', undefined)
+        expect(result).toBe('babyName')
+        done()
+      })
+    })
   })
   describe('getAllTables', () => {
     it('should return all tables of a particular schema from a database', (done) => {


### PR DESCRIPTION
Just a little tweak :) I have a table called "dependencies" that was being changed to "dependencie" when singularTableNames was set! I've added a test for the new behaviour so if you're happy including my change, it should be an easy merge.

Thanks!
Alex