### PR TITLE
Sort columns based on lexicographic order

### DIFF
--- a/src/ColumnTasks.ts
+++ b/src/ColumnTasks.ts
@@ -19,6 +19,7 @@ import * as SchemaTasks from './SchemaTasks'
 export async function getColumnsForTable (db: Knex, table: TableDefinition, config: Config): Promise<Column[]> {
   const adapter = AdapterFactory.buildAdapter(db.client.dialect)
   const columns = await adapter.getAllColumns(db, config, table.name, table.schema)
+  columns.sort((a, b) => a.name.localeCompare(b.name))
   return columns.map(c => (
     {
       ...c,


### PR DESCRIPTION
# Changes
This PR will sort the columns based on lexicographic order instead of whatever the underlying adapter returns

# Rationale
Currently, the order of the columns in the generated types is undefined.  In Postgres (which is what we use), the DB appears to return columns are returned in the order they are created in the database.  This is fine and usually results in no issues if columns are created across multiple transactions which is the normal use-case for us.  (We use Knex migrations and commit them to the codebase as we need to migrate the DB).  

However, if you create all columns in a single transaction, this ordering is violated.  This is what we encountered when we tried to generate types from a test DB which we bring up from scratch in CI to run DB-driven tests against. 

With this PR, the order returned by the adapter no longer matters because we sort them after they are returned so DB types should have the same order in the generated types regardless of how the DB was migrated.