### PR TITLE
Adds support for exporting column default values

### DIFF
--- a/src/Adapters/AdapterInterface.ts
+++ b/src/Adapters/AdapterInterface.ts
@@ -31,6 +31,7 @@ export interface ColumnDefinition {
   // The schema the enum belongs to. Currently only used for postgres.
   enumSchema?: string;
   comment: string
+  defaultValue: any;
 }
 
 /**

--- a/src/Adapters/mssql.ts
+++ b/src/Adapters/mssql.ts
@@ -57,7 +57,8 @@ export default class implements AdapterInterface {
           optional: c.isOptional === 1 || c.isNullable == 'YES',
           isEnum: false,
           isPrimaryKey: c.isPrimaryKey == 1,
-          comment: c.comment
+          comment: c.comment,
+          defaultValue: null, // TODO
       }) as ColumnDefinition)
   }
 }

--- a/src/Adapters/mysql.ts
+++ b/src/Adapters/mysql.ts
@@ -48,7 +48,8 @@ export default class implements AdapterInterface {
           optional: c.isOptional === 1,
           isEnum: false,
           isPrimaryKey: c.isPrimaryKey == 1,
-          comment: c.comment
+          comment: c.comment,
+          defaultValue: null, // TODO
         }
       ) as ColumnDefinition)
   }

--- a/src/Adapters/postgres.ts
+++ b/src/Adapters/postgres.ts
@@ -91,7 +91,8 @@ export default class implements AdapterInterface {
           isEnum: c.typcategory == 'E',
           isPrimaryKey: c.isprimarykey == 1,
           enumSchema: c.typeschema,
-          comment: c.comment
+          comment: c.comment,
+          defaultValue: null, // TODO
         }) as ColumnDefinition)
   }
 }

--- a/src/Adapters/sqlite.ts
+++ b/src/Adapters/sqlite.ts
@@ -3,6 +3,8 @@ import { AdapterInterface, TableDefinition, ColumnDefinition, EnumDefinition } f
 import { Config } from '..'
 import * as SharedAdapterTasks from './SharedAdapterTasks'
 
+// SQLite default values are always strings regardless of the column types. So
+// here we convert it to the correct type.
 const formatDefaultValue = (value:string | null, type: string):null | number | string => {
   if (value === null) return value;
 
@@ -30,7 +32,7 @@ const formatDefaultValue = (value:string | null, type: string):null | number | s
     'DATETIME',
   ];
 
-  // SQLite default values are always surrounded by quote - eg `"3"` (for
+  // SQLite default values are always surrounded by quotes - eg `"3"` (for
   // numeric value 3) or `"example"` (for string `example`). So here we remove
   // the quotes, but to safe we check that they are actually present.
   if (value.length && value[0] === '"') value = value.substr(1);

--- a/src/Adapters/sqlite.ts
+++ b/src/Adapters/sqlite.ts
@@ -3,6 +3,48 @@ import { AdapterInterface, TableDefinition, ColumnDefinition, EnumDefinition } f
 import { Config } from '..'
 import * as SharedAdapterTasks from './SharedAdapterTasks'
 
+const formatDefaultValue = (value:string | null, type: string):null | number | string => {
+  if (value === null) return value;
+
+  // From https://www.sqlite.org/datatype3.html
+  //
+  // Note that DECIMAL(10,5) is also a valid type - this is checked in the
+  // conditional below
+  const numericTypes = [
+    'INT',
+    'INTEGER',
+    'TINYINT',
+    'SMALLINT',
+    'MEDIUMINT',
+    'BIGINT',
+    'UNSIGNED BIG INT',
+    'INT2',
+    'INT8',
+    'REAL',
+    'DOUBLE',
+    'DOUBLE PRECISION',
+    'FLOAT',
+    'NUMERIC',
+    'BOOLEAN',
+    'DATE',
+    'DATETIME',
+  ];
+
+  // SQLite default values are always surrounded by quote - eg `"3"` (for
+  // numeric value 3) or `"example"` (for string `example`). So here we remove
+  // the quotes, but to safe we check that they are actually present.
+  if (value.length && value[0] === '"') value = value.substr(1);
+  if (value.length && value[value.length - 1] === '"') value = value.substr(0, value.length - 1);
+
+  type = type.toUpperCase();
+
+  if (numericTypes.includes(type) || type.startsWith('DECIMAL')) {
+    return Number(value);
+  } else {
+    return value;
+  }
+}
+
 export default class implements AdapterInterface {
   async getAllEnums(db: Knex, config: Config): Promise<EnumDefinition[]> {
     return await SharedAdapterTasks.getTableEnums(db, config)
@@ -26,7 +68,8 @@ export default class implements AdapterInterface {
         optional: c.dflt_value !== null || c.notnull === 0 || c.pk !== 0,
         isEnum: false,
         isPrimaryKey: c.pk !== 0,
-        comment: ''
+        comment: '',
+        defaultValue: formatDefaultValue(c.dflt_value, c.type),
       } as ColumnDefinition
     ))
   }

--- a/src/specs/Adapters/mssql.spec.ts
+++ b/src/specs/Adapters/mssql.spec.ts
@@ -108,7 +108,8 @@ describe('mssql', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         },
         {
           name: 'name2',
@@ -117,7 +118,8 @@ describe('mssql', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: false,
-          comment: 'comment2'
+          comment: 'comment2',
+          defaultValue: null,
         },
         {
           name: 'name3',
@@ -126,7 +128,8 @@ describe('mssql', () => {
           optional: false,
           isEnum: false,
           isPrimaryKey: false,
-          comment: 'comment3'
+          comment: 'comment3',
+          defaultValue: null,
         },
         {
           name: 'name4',
@@ -135,7 +138,8 @@ describe('mssql', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: false,
-          comment: 'comment4'
+          comment: 'comment4',
+          defaultValue: null,
         },
       ])
     })

--- a/src/specs/Adapters/mysql.spec.ts
+++ b/src/specs/Adapters/mysql.spec.ts
@@ -88,7 +88,8 @@ describe('mysql', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         },
         {
           name: 'name2',
@@ -97,7 +98,8 @@ describe('mysql', () => {
           optional: false,
           isEnum: false,
           isPrimaryKey: false,
-          comment: 'comment2'
+          comment: 'comment2',
+          defaultValue: null,
         },
       ])
     })

--- a/src/specs/Adapters/postgres.spec.ts
+++ b/src/specs/Adapters/postgres.spec.ts
@@ -139,7 +139,8 @@ describe('postgres', () => {
           optional: true,
           isEnum: true,
           isPrimaryKey: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         },
         {
           name: 'name2',
@@ -149,7 +150,8 @@ describe('postgres', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true,
-          comment: 'comment2'
+          comment: 'comment2',
+          defaultValue: null,
         },
         {
           name: 'name3',
@@ -159,7 +161,8 @@ describe('postgres', () => {
           optional: true,
           isEnum: true,
           isPrimaryKey: false,
-          comment: 'comment3'
+          comment: 'comment3',
+          defaultValue: null,
         },
         {
           name: 'name4',
@@ -169,7 +172,8 @@ describe('postgres', () => {
           optional: false,
           isEnum: false,
           isPrimaryKey: false,
-          comment: ''
+          comment: '',
+          defaultValue: null,
         },
       ])
     })

--- a/src/specs/Adapters/sqlite.spec.ts
+++ b/src/specs/Adapters/sqlite.spec.ts
@@ -54,7 +54,7 @@ describe('sqlite', () => {
           name: 'name1',
           notnull: 0,
           type: 'type(123)',
-          dflt_value: null,
+          dflt_value: 10,
           pk: 0
         }
       ]
@@ -73,7 +73,8 @@ describe('sqlite', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: false,
-          comment: ''
+          comment: '',
+          defaultValue: 10,
         }
       ])
     })
@@ -102,7 +103,8 @@ describe('sqlite', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: false,
-          comment: ''
+          comment: '',
+          defaultValue: '1234',
         }
       ])
     })
@@ -138,7 +140,8 @@ describe('sqlite', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true,
-          comment: ''
+          comment: '',
+          defaultValue: null,
         },
         {
           name: 'name2',
@@ -147,7 +150,8 @@ describe('sqlite', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true,
-          comment: ''
+          comment: '',
+          defaultValue: null,
         }
       ])
     })
@@ -176,7 +180,8 @@ describe('sqlite', () => {
           optional: false,
           isEnum: false,
           isPrimaryKey: false,
-          comment: ''
+          comment: '',
+          defaultValue: null,
         }
       ])
     })
@@ -205,7 +210,8 @@ describe('sqlite', () => {
           optional: true,
           isEnum: false,
           isPrimaryKey: true,
-          comment: ''
+          comment: '',
+          defaultValue: null,
         }
       ])
     })

--- a/src/specs/ColumnTasks.spec.ts
+++ b/src/specs/ColumnTasks.spec.ts
@@ -17,7 +17,8 @@ describe('ColumnTasks', () => {
           optional: false,
           isEnum: false,
           isPrimaryKey: true,
-          comment: 'cname comment'
+          comment: 'cname comment',
+          defaultValue: null,
         }
       ]
       const mockAdapter = {
@@ -96,7 +97,8 @@ describe('ColumnTasks', () => {
         nullable: false,
         optional: false,
         type: 'enum type',
-        comment: 'comment'
+        comment: 'comment',
+        defaultValue: null,
       }
       const mockConfig: Config = {
         globalOptionality: 'required',
@@ -114,7 +116,8 @@ describe('ColumnTasks', () => {
         nullable: false,
         optional: true,
         type: 'enum type',
-        comment: 'comment'
+        comment: 'comment',
+        defaultValue: null,
       }
       const mockConfig: Config = {
         globalOptionality: 'optional',
@@ -132,7 +135,8 @@ describe('ColumnTasks', () => {
         nullable: false,
         optional: true,
         type: 'enum type',
-        comment: 'comment'
+        comment: 'comment',
+        defaultValue: null,
       }
       const mockConfig: Config = {
         globalOptionality: 'dynamic',
@@ -150,7 +154,8 @@ describe('ColumnTasks', () => {
         nullable: false,
         optional: false,
         type: 'enum type',
-        comment: 'comment'
+        comment: 'comment',
+        defaultValue: null,
       }
       const mockConfig: Config = {
         globalOptionality: 'dynamic',
@@ -168,7 +173,8 @@ describe('ColumnTasks', () => {
         nullable: false,
         optional: false,
         type: 'enum type',
-        comment: 'comment'
+        comment: 'comment',
+        defaultValue: null,
       }
       const mockConfig: Config = {
         globalOptionality: 'dynamic',
@@ -198,7 +204,8 @@ describe('ColumnTasks', () => {
           nullable: false,
           optional: false,
           type: 'enum type',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockTable = {}
         const mockConfig = {}
@@ -226,7 +233,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           schema: 'schema',
           name: 'table',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn: ColumnDefinition = {
           isEnum: false,
@@ -235,7 +243,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig: Config = {
           typeOverrides: { },
@@ -266,7 +275,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           schema: 'schema',
           name: 'table',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn = {
           isEnum: false,
@@ -275,7 +285,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig: Config = {
           typeOverrides: { },
@@ -296,7 +307,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           name: 'tableName',
           schema: 'schema',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn: ColumnDefinition = {
           name: 'tofind',
@@ -305,7 +317,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig: Config = {
           typeMap: {
@@ -329,7 +342,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           name: 'tableName',
           schema: 'schema',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn = {
           name: 'column',
@@ -338,7 +352,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig: Config = {
           typeMap: {
@@ -356,7 +371,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           name: 'tableName',
           schema: 'schema',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn: ColumnDefinition = {
           name: 'cname',
@@ -365,7 +381,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig = {
           typeOverrides: {
@@ -387,7 +404,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           name: 'tableName',
           schema: 'schema',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn = {
           name: 'column',
@@ -396,7 +414,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig = {
           typeOverrides: { 'schema.tableName.column': 'overridetype' },
@@ -431,7 +450,8 @@ describe('ColumnTasks', () => {
         const mockTable = {
           name: 'table',
           schema: 'schema',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockColumn: ColumnDefinition = {
           name: 'column',
@@ -440,7 +460,8 @@ describe('ColumnTasks', () => {
           isPrimaryKey: false,
           nullable: false,
           optional: false,
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const result = MockColumnTasks.convertType(mockColumn, mockTable, mockConfig, 'dialect')
         expect(mockGenerateFullColumnName).toHaveBeenCalledOnceWith('table', 'schema', 'column')
@@ -469,7 +490,8 @@ describe('ColumnTasks', () => {
           optional: false,
           type: 'enum type',
           enumSchema: 'enum schema',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig = {
           schemaAsNamespace: true
@@ -499,6 +521,7 @@ describe('ColumnTasks', () => {
           optional: false,
           type: 'enum type',
           comment: 'enum comment',
+          defaultValue: null,
         }
         const mockConfig = {
           schemaAsNamespace: true
@@ -528,7 +551,8 @@ describe('ColumnTasks', () => {
           optional: false,
           type: 'enum type',
           enumSchema: 'enum schema',
-          comment: 'enum comment'
+          comment: 'enum comment',
+          defaultValue: null,
         }
         const mockConfig = {
           schemaAsNamespace: false
@@ -557,7 +581,8 @@ describe('ColumnTasks', () => {
           nullable: false,
           optional: false,
           type: 'enum type',
-          comment: 'comment'
+          comment: 'comment',
+          defaultValue: null,
         }
         const mockConfig = {
           schemaAsNamespace: false


### PR DESCRIPTION
Currently the `ColumnDefinition` object doesn't contain the column default values, even though this is exposed by certain adapter (in particular SQLite has the `dflt_value` property). This pull request adds support for this default value.

For now I've added support for the SQLite adapters but other ones could now be supported easily if someone's interested.

I can also add the documentation if needed (although I'm not sure how it's generated at the moment).