### PR TITLE
Allow excludedTables config to take a predicate function instead of a hardcoded list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,33 @@ Excluding a table takes precedence over including it. Specifying a table in both
   ]
 }
 ```
+
+<!-- div:left-panel -->
+
+Alternatively, you can pass a function for `excludedTables` that receives the following object:
+
+```ts
+interface TableDefinition {
+  schema: string;
+  name: string;
+  comment: string;
+}
+
+type excludedTables = (tableDefinition: TableDefinition) => boolean
+```
+
+<!-- div:right-panel -->
+
+And use it like so:
+```ts
+import sqlts from "@rmp135/sql-ts"
+
+const tsString = await sqlts.toTypeScript({
+  // exclude all tables whose name begins with underscore, eg `_users`
+  excludedTables: (tableDefinition) => /^_/.test(tableDefinition.name)
+})
+```
+
 <!-- div:title-panel -->
 ### typeOverrides
 <!-- div:left-panel -->

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -10,7 +10,7 @@ import { ColumnDefinition, TableDefinition } from './Adapters/AdapterInterface'
  */
 export interface Config extends Knex.Config {
   tables?: string[],
-  excludedTables?: string[],
+  excludedTables?: string[] | ((tableDefinition: TableDefinition) => boolean),
   filename?: string,
   folder?: string,
   interfaceNameFormat?: string,


### PR DESCRIPTION
This is the first in a series of PRs that we intend to open that extend `sql-ts` to be more flexible when used with a javascript config, rather than a static JSON config.

Please, let me know if this is a direction you're interested in supporting, and if not I won't bother you with the rest.

The other planned ones are:
 - being able to do type overrides with a callback function
 - extending MySQL enum handing