### PR TITLE
Add "sortColumn" option for handling columns order

### DIFF
--- a/src/ColumnTasks.ts
+++ b/src/ColumnTasks.ts
@@ -19,7 +19,9 @@ import * as SchemaTasks from './SchemaTasks'
 export async function getColumnsForTable (db: Knex, table: TableDefinition, config: Config): Promise<Column[]> {
   const adapter = AdapterFactory.buildAdapter(db.client.dialect)
   const columns = await adapter.getAllColumns(db, config, table.name, table.schema)
-  columns.sort((a, b) => a.name.localeCompare(b.name))
+  if (config.sortColumn === 'alphabet') {
+    columns.sort((a, b) => a.name.localeCompare(b.name))
+  }
   return columns.map(column => (
     {
       ...column,

--- a/src/ConfigTasks.ts
+++ b/src/ConfigTasks.ts
@@ -13,6 +13,7 @@ export function applyConfigDefaults(config: Config): Config {
     globalOptionality: 'dynamic',
     columnOptionality: {},
     tableEnums: {},
+    sortColumn: 'alphabet',
     folder: '.',
     tables: [],
     excludedTables: [],

--- a/src/Typings.ts
+++ b/src/Typings.ts
@@ -33,7 +33,8 @@ export interface Config extends Knex.Config {
   globalOptionality?: 'optional' | 'required' | 'dynamic'
   columnOptionality?: {
     [key: string]: 'optional' | 'required' | 'dynamic'
-  }
+  },
+  sortColumn: 'origin' | 'alphabet',
   typeMap?: {
     [key: string]: string[]
   }


### PR DESCRIPTION
In Config, provide a new option called `sortColumn`,
sortColumn can have 2 values,
- origin
- alphabet(default)

If set sortColumn to origin, we won't sort columns and generate interface with original order.

Related issue: https://github.com/rmp135/sql-ts/issues/127