### PR TITLE
Don't treat postgres table partitions as separate tables

### DIFF
--- a/src/Adapters/postgres.ts
+++ b/src/Adapters/postgres.ts
@@ -48,6 +48,7 @@ export default {
         FROM pg_class
             JOIN schemas ON schemas.oid = pg_class.relnamespace
         WHERE pg_class.relkind IN ('r', 'p', 'v', 'm')
+        AND NOT pg_class.relispartition
     `
     const results = await db.raw(sql, { schemas }) as { rows: TableDefinition[] }
     return results.rows


### PR DESCRIPTION
In the currently released version postgres table partitions are treated as separate tables. This can result in an explosion of duplicate types.

This PR ignores partitions when listing tables. The other db adapters may also benefit from similar changes.