### PR TITLE
Allowing looser peer dependencies to allow installation with newer versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,21 +32,21 @@
         "@types/pg": "^8.11.2",
         "@types/yargs": "^17.0.32",
         "@vitest/coverage-v8": "^1.3.1",
-        "better-sqlite3": "^9.4.3",
+        "better-sqlite3": ">=11.2.1",
         "copyfiles": "^2.4.1",
         "docsify-cli": "^4.4.4",
-        "mssql": "^10.0.2",
-        "mysql2": "^3.9.2",
-        "pg": "^8.11.3",
+        "mssql": ">=10.0.2",
+        "mysql2": ">=3.9.2",
+        "pg": ">=8.11.3",
         "typescript": "^5.3.3",
         "vitest": "^1.3.1"
       },
       "peerDependencies": {
-        "better-sqlite3": "^11.2.1",
-        "mssql": "^10.0.2",
-        "mysql2": "^3.9.2",
-        "pg": "^8.11.3",
-        "sqlite3": "^5.1.7"
+        "better-sqlite3": ">=11.2.1",
+        "mssql": ">=10.0.2",
+        "mysql2": ">=3.9.2",
+        "pg": ">=8.11.3",
+        "sqlite3": ">=5.1.7"
       },
       "peerDependenciesMeta": {
         "better-sqlite3": {
@@ -1786,14 +1786,18 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.4.3.tgz",
-      "integrity": "sha512-ud0bTmD9O3uWJGuXDltyj3R47Nz0OHX8iqPOT5PMspGqlu/qQFn+5S2eFBUCrySpavTjFXbi4EgrfVvPAHlImw==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/binary-extensions": {
@@ -9006,9 +9010,9 @@
       }
     },
     "better-sqlite3": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.4.3.tgz",
-      "integrity": "sha512-ud0bTmD9O3uWJGuXDltyj3R47Nz0OHX8iqPOT5PMspGqlu/qQFn+5S2eFBUCrySpavTjFXbi4EgrfVvPAHlImw==",
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "dev": true,
       "requires": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "docs:serve": "docsify serve docs"
   },
   "peerDependencies": {
-    "better-sqlite3": "^11.2.1",
-    "mssql": "^10.0.2",
-    "mysql2": "^3.9.2",
-    "pg": "^8.11.3",
-    "sqlite3": "^5.1.7"
+    "better-sqlite3": ">=11.2.1",
+    "mssql": ">=10.0.2",
+    "mysql2": ">=3.9.2",
+    "pg": ">=8.11.3",
+    "sqlite3": ">=5.1.7"
   },
   "peerDependenciesMeta": {
     "mssql": {
@@ -76,12 +76,12 @@
     "@types/pg": "^8.11.2",
     "@types/yargs": "^17.0.32",
     "@vitest/coverage-v8": "^1.3.1",
-    "better-sqlite3": "^9.4.3",
+    "better-sqlite3": ">=11.2.1",
     "copyfiles": "^2.4.1",
     "docsify-cli": "^4.4.4",
-    "mssql": "^10.0.2",
-    "mysql2": "^3.9.2",
-    "pg": "^8.11.3",
+    "mssql": ">=10.0.2",
+    "mysql2": ">=3.9.2",
+    "pg": ">=8.11.3",
     "typescript": "^5.3.3",
     "vitest": "^1.3.1"
   }


### PR DESCRIPTION
The dependencies specified in the package.json (and package-lock.json) are very tight. If I want to use a newer version in my project the installation will fail with a `^x.x.x` dependency range. `>=x.x.x` will allow the installation with newer versions.

Also updates the dev dependencies to make sure that the test environment uses matching versions